### PR TITLE
fix(terminal): skip Windows WSL launcher in _find_bash

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -175,6 +175,30 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     return sanitized
 
 
+def _is_windows_wsl_launcher(path: str) -> bool:
+    """Return True if *path* is the Windows-bundled WSL launcher (``bash.exe``).
+
+    Windows 10/11 ship ``C:\\Windows\\System32\\bash.exe`` as a launcher for
+    WSL (the ``lxss``/``wsl.exe`` interop entry point). The file is present
+    even when no WSL distro is installed, and ``shutil.which("bash")`` will
+    happily return it because ``System32`` is high-priority on the default
+    ``PATH``. Invoking it either hangs (waiting on a WSL VM that never comes
+    up) or exits with ``wsl: ...`` style errors. It is *not* Git Bash and
+    must not be used as one — doing so wedges every terminal call on the
+    ``local`` backend until ``gateway_timeout`` fires.
+    """
+    try:
+        resolved = os.path.normcase(os.path.realpath(path))
+    except OSError:
+        resolved = os.path.normcase(path)
+    system_root = os.environ.get("SystemRoot", r"C:\Windows")
+    bad_locations = {
+        os.path.normcase(os.path.join(system_root, sub, "bash.exe"))
+        for sub in ("System32", "Sysnative", "SysWOW64")
+    }
+    return resolved in bad_locations
+
+
 def _find_bash() -> str:
     """Find bash for command execution."""
     if not _IS_WINDOWS:
@@ -209,8 +233,13 @@ def _find_bash() -> str:
             if os.path.isfile(candidate):
                 return candidate
 
+    # ``shutil.which("bash")`` on Windows resolves to ``C:\Windows\System32\
+    # bash.exe`` first when the WSL launcher is present (true on every stock
+    # Win10/11). That binary is *not* Git Bash — invoking it hangs the
+    # terminal tool. Skip it and fall through to the known Git for Windows
+    # install paths below.
     found = shutil.which("bash")
-    if found:
+    if found and not _is_windows_wsl_launcher(found):
         return found
 
     for candidate in (
@@ -224,7 +253,9 @@ def _find_bash() -> str:
     raise RuntimeError(
         "Git Bash not found. Hermes Agent requires Git for Windows on Windows.\n"
         "Install it from: https://git-scm.com/download/win\n"
-        "Or set HERMES_GIT_BASH_PATH to your bash.exe location."
+        "Or set HERMES_GIT_BASH_PATH to your bash.exe location.\n"
+        "Note: C:\\Windows\\System32\\bash.exe is intentionally ignored — "
+        "it is the WSL launcher, not Git Bash."
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #1.

On Windows, `shutil.which("bash")` resolves to `C:\Windows\System32\bash.exe` whenever the WSL launcher is present (true on every stock Win10/11). That binary is the WSL launcher, **not** Git Bash; calling it as bash hangs the terminal tool until `gateway_timeout` fires, taking the entire agent down with it.

This PR adds an `_is_windows_wsl_launcher()` guard and filters the `shutil.which` result through it in `_find_bash`, so the function falls through to the existing Git for Windows install paths.

## What changed

- New helper `_is_windows_wsl_launcher(path)` — matches `%SystemRoot%\System32\bash.exe` plus the `Sysnative\` and `SysWOW64\` 32/64-bit aliases, via `os.path.realpath` + `normcase` so symlink/redirect variants are caught.
- `_find_bash` now skips the `shutil.which` result when it points at the WSL launcher.
- `RuntimeError` message extended with an explicit note that `System32\bash.exe` is intentionally ignored, to short-circuit future debugging.

## Verification

Locally on Win11 (Git for Windows installed at `C:\Program Files\Git\bin\bash.exe`, no WSL distro, `HERMES_GIT_BASH_PATH` unset):

**Before the patch** — agent freezes on the first `terminal` call; `gateway.log` eventually reports `Agent idle for 1802s (timeout 1800s) ... last_activity=executing tool: terminal`.

**After the patch** — `_find_bash()` returns `C:\Program Files\Git\bin\bash.exe`; terminal calls complete normally:

```python
from tools.environments.local import _find_bash, _is_windows_wsl_launcher
assert _is_windows_wsl_launcher(r"C:\Windows\System32\bash.exe")
assert not _is_windows_wsl_launcher(r"C:\Program Files\Git\bin\bash.exe")
print(_find_bash())
# -> C:\Program Files\Git\bin\bash.exe
```

## Test plan

- [x] Manually verified `_find_bash` resolves to Git for Windows after the patch on an affected machine.
- [x] Manually verified `_is_windows_wsl_launcher` true-positive on `System32\bash.exe` (with case variants) and true-negative on `Program Files\Git\bin\bash.exe`.
- [ ] Add a unit test under `tests/tools/environments/` mocking `shutil.which` / `os.path.isfile` / `SystemRoot` to cover both branches (happy to do in a follow-up if reviewers prefer).
- [ ] Smoke-test on a clean Win11 + no-WSL machine via real `hermes gateway run` + a Feishu DM that triggers the `terminal` tool.

## Notes

- Upstream `NousResearch/hermes-agent` is affected by the same code; recommend forwarding once this is reviewed so the next upstream sync doesn't regress the fix.
- The pre-existing `HERMES_GIT_BASH_PATH` workaround still applies for users on older releases.
