### PR TITLE
fix(deps): pull in PySocks via requests[socks] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "rich>=14.3.3,<15",
   "tenacity>=9.1.4,<10",
   "pyyaml>=6.0.2,<7",
-  "requests>=2.33.0,<3",  # CVE-2026-25645
+  "requests[socks]>=2.33.0,<3",  # CVE-2026-25645; [socks] pulls in PySocks for SOCKS proxy support (needed by lark-oapi etc. when ALL_PROXY=socks5://...)
   "jinja2>=3.1.5,<4",
   "pydantic>=2.12.5,<3",
   # Interactive CLI (prompt_toolkit is used directly by cli.py)


### PR DESCRIPTION
## Summary

Hermes already declares `httpx[socks]` (which pulls in `socksio` for httpx's SOCKS path) but `requests` is declared without the `[socks]` extra. SDKs that go through `requests`/`urllib3` under the hood — most visibly `lark-oapi` (Feishu) but also any other adapter that ultimately calls into `requests` — fail to honor a SOCKS proxy with:

```
Lark: connect failed, err: Missing dependencies for SOCKS support.
```

On affected setups this manifests as the Feishu websocket never actually establishing (despite the misleading `Connected in websocket mode` startup log), and inbound DMs being silently dropped. Workaround until now: manually `pip install PySocks` into the venv.

This PR switches `requests>=2.33.0,<3` to `requests[socks]>=2.33.0,<3`. The `[socks]` extra is defined by upstream `requests` itself (`PySocks!=1.5.7,>=1.5.6`), so we're not adding a new top-level pin — just opting in to the SOCKS transitive that `requests` already maintains. `requests` auto-detects `PySocks` at import; no code changes are needed elsewhere.

## Repro (before this PR)

1. On any OS, with a SOCKS proxy running (e.g. Clash/Mihomo on `127.0.0.1:7897`).
2. Set `ALL_PROXY=socks5://127.0.0.1:7897` at the user/process scope.
3. Install hermes-agent fresh (no manual `PySocks` install) and start the gateway with the Feishu platform enabled.
4. Observe in `~/.hermes/logs/gateway.log`: `[Feishu] Connected in websocket mode (feishu)` and `✓ feishu connected`.
5. Observe in `~/.hermes/logs/errors.log`: every ~2 minutes:
   ```
   ERROR Lark: connect failed, err: Missing dependencies for SOCKS support.
   INFO  Lark: trying to reconnect for the Nth time
   ```
6. Send a Feishu DM to the bot. Nothing reaches `gateway.run: inbound message`. Silent drop.

## After this PR

`PySocks` is installed as a transitive of `requests`. `lark-oapi`'s websocket connection succeeds on the first try; inbound DMs land in `gateway.run` normally. Manually verified on Win11 + Clash mixed-port 7897 + `ALL_PROXY=socks5://...`.

## Why touch `requests` rather than `feishu` extras?

This is not Feishu-specific — any `requests`/`urllib3`-based SDK in the dependency tree will hit the same wall under a SOCKS proxy. Putting `PySocks` behind the core `requests` declaration makes the fix apply uniformly to telegram, discord, and any future adapter that ends up routing through `requests`, without having to chase the extras list per-platform.

## Test plan

- [x] Manual: Feishu DM round-trip succeeds with `ALL_PROXY=socks5://127.0.0.1:7897` after a fresh install + `pip install -e .`.
- [x] `python -c "import socks; print(socks.__version__)"` resolves inside the venv after install.
- [x] No errors of the form `Missing dependencies for SOCKS support` in `~/.hermes/logs/errors.log` after restart.
- [ ] CI dependency-resolution still passes (one-liner, no version drift, should be trivially green).

## Notes

- Same issue exists upstream `NousResearch/hermes-agent` — recommend forwarding once reviewed so the next upstream sync doesn't regress.
- Loosely related to #1 / #2 (Windows `_find_bash` WSL launcher bug) — both were uncovered during the same Feishu debugging session, but the root causes are independent.
