### PR TITLE
feat(P-009): SSE+POST transport + runtime release pipeline

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -1,0 +1,185 @@
+# Build, sign, and publish hermes-agent-cn runtime artifacts that the
+# hermes-cn-desktop-v2 client downloads on first launch.
+#
+# Trigger: push a tag matching `runtime-v*` (e.g. `runtime-v0.13.0`).
+# Per-platform jobs build a self-contained executable via PyInstaller,
+# zip it, sign the manifest with Ed25519, and attach all artifacts to a
+# GitHub Release.
+#
+# Required repository secret:
+#   RUNTIME_SIGN_PRIVATE_KEY_PEM
+#     The Ed25519 PEM-encoded private key. The matching public key is
+#     baked into the desktop binary via the HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM_DEFAULT
+#     env var at build time. See docs/RUNTIME_RELEASES.md.
+#
+# Caveats (track in follow-up issues, not blockers for first run):
+#   - PyInstaller's autodetection misses lazy-imported provider SDKs
+#     (anthropic, firecrawl-py, etc.). Add them to hidden-imports as the
+#     ecosystem grows. The agent's `tools/lazy_deps.py` install flow won't
+#     work inside a frozen binary anyway — only the providers we pre-bake
+#     are usable. That's acceptable for v1; revisit when users complain.
+#   - Antivirus on Windows occasionally flags PyInstaller output. Sign
+#     the .exe (Authenticode) once you've registered a code-signing cert.
+#     Until then, document the false-positive in the release notes.
+
+name: release-runtime
+
+on:
+  push:
+    tags:
+      - "runtime-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Semver to tag the manifest with (e.g. 0.13.0+cn.20260516)"
+        required: true
+      channel:
+        description: "Release channel"
+        default: stable
+        type: choice
+        options: [stable, beta, canary]
+
+permissions:
+  contents: write  # needed to create the Release + upload assets
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-latest
+            platform: win32
+            arch: x64
+            ext: .exe
+          - runner: macos-latest
+            platform: darwin
+            arch: arm64
+            ext: ""
+          - runner: ubuntu-latest
+            platform: linux
+            arch: x64
+            ext: ""
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version + channel
+        id: meta
+        shell: bash
+        run: |
+          if [[ -n "${{ github.event.inputs.version }}" ]]; then
+            VERSION="${{ github.event.inputs.version }}"
+            CHANNEL="${{ github.event.inputs.channel }}"
+          else
+            # tag is `runtime-v<semver>`; strip the prefix
+            VERSION="${GITHUB_REF_NAME#runtime-v}"
+            CHANNEL="stable"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build deps + agent
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          # Install the package itself so PyInstaller can import the entry point
+          pip install -e .
+          # Build tooling
+          pip install pyinstaller==6.* cryptography
+
+      - name: Build self-contained executable
+        shell: bash
+        run: |
+          # --onedir gives us a folder with shared libs + the binary; the
+          # client expects an executable named hermes-agent-cn-runtime-<platform>-<arch>{.ext}.
+          # Hidden imports cover modules PyInstaller doesn't discover via
+          # static analysis (lazy imports inside hermes_cli/main.py).
+          NAME="hermes-agent-cn-runtime-${{ matrix.platform }}-${{ matrix.arch }}"
+          pyinstaller --noconfirm \
+            --name "$NAME" \
+            --onedir \
+            --console \
+            --collect-submodules hermes_cli \
+            --collect-submodules tui_gateway \
+            --hidden-import gateway.status \
+            --paths . \
+            -p . \
+            hermes_cli/main.py
+          ls -la "dist/$NAME"
+
+      - name: Smoke-test the binary
+        shell: bash
+        run: |
+          NAME="hermes-agent-cn-runtime-${{ matrix.platform }}-${{ matrix.arch }}"
+          "./dist/$NAME/$NAME${{ matrix.ext }}" dashboard --help
+
+      - name: Zip artifact
+        shell: bash
+        run: |
+          NAME="hermes-agent-cn-runtime-${{ matrix.platform }}-${{ matrix.arch }}"
+          mkdir -p out
+          if [[ "${{ matrix.platform }}" == "win32" ]]; then
+            # PowerShell Compress-Archive on Windows runner
+            powershell -Command "Compress-Archive -Path dist/$NAME/* -DestinationPath out/$NAME.zip -Force"
+          else
+            (cd dist && zip -r "../out/$NAME.zip" "$NAME")
+          fi
+          ls -la out
+
+      - name: Sign manifest
+        shell: bash
+        env:
+          RUNTIME_SIGN_PRIVATE_KEY_PEM: ${{ secrets.RUNTIME_SIGN_PRIVATE_KEY_PEM }}
+        run: |
+          NAME="hermes-agent-cn-runtime-${{ matrix.platform }}-${{ matrix.arch }}"
+          # Anticipate the URL the Release will publish at — this has to
+          # match exactly because the signature covers it.
+          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${NAME}.zip"
+          python scripts/sign_runtime_manifest.py \
+            --channel "${{ steps.meta.outputs.channel }}" \
+            --version "${{ steps.meta.outputs.version }}" \
+            --platform "${{ matrix.platform }}" \
+            --arch "${{ matrix.arch }}" \
+            --artifact-url "$URL" \
+            --artifact-path "out/$NAME.zip" \
+            --upstream-repo "${GITHUB_REPOSITORY}" \
+            --upstream-commit "${GITHUB_SHA}" \
+            --output "out/${{ matrix.platform }}-${{ matrix.arch }}.json"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-${{ matrix.platform }}-${{ matrix.arch }}
+          path: out/
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist/
+
+      - name: List downloaded
+        run: find dist -type f
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          # When running via workflow_dispatch there is no tag — skip the
+          # release step in that case (still useful for testing the build).
+          tag_name: ${{ github.ref_name }}
+          files: |
+            dist/**/*.zip
+            dist/**/*.json
+          fail_on_unmatched_files: false
+          draft: false
+          prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+        if: startsWith(github.ref, 'refs/tags/runtime-v')

--- a/docs/RUNTIME_RELEASES.md
+++ b/docs/RUNTIME_RELEASES.md
@@ -1,0 +1,121 @@
+# Runtime release pipeline
+
+The hermes-cn-desktop-v2 client (Tauri desktop app) downloads a
+hermes-agent-cn runtime on first launch and uses it to spawn the
+dashboard subprocess. This document describes how that runtime is built,
+signed, and published.
+
+## Wire shape
+
+The client expects a per-platform manifest JSON at:
+
+```
+${HERMES_RUNTIME_UPDATE_BASE_URL}/${channel}/${platform}-${arch}.json
+```
+
+For example with the GitHub Releases base URL:
+
+```
+https://github.com/Eynzof/hermes-agent-cn/releases/download/runtime-v0.13.0/stable/win32-x64.json
+```
+
+The manifest schema (see `src/process/runtime.rs::RuntimeUpdateManifest`
+on the desktop side):
+
+```json
+{
+  "channel": "stable",
+  "version": "0.13.0+cn.20260516",
+  "platform": "win32",
+  "arch": "x64",
+  "artifactUrl": "https://.../runtime-win32-x64.zip",
+  "sha256": "abcdef0123...",
+  "signature": "base64-encoded Ed25519 signature",
+  "upstreamRepo": "Eynzof/hermes-agent-cn",
+  "upstreamCommit": "01edd139...",
+  "minAppVersion": "0.1.0",
+  "createdAt": "2026-05-16T03:00:00Z"
+}
+```
+
+The signature is over the eight canonical fields concatenated with `\n`
+in this exact order:
+
+```
+channel\nplatform\narch\nversion\nartifactUrl\nsha256\nupstreamRepo\nupstreamCommit
+```
+
+`scripts/sign_runtime_manifest.py` builds this payload identically to
+how the desktop verifies it (`signature_payload()` in `runtime.rs`).
+**Any field-order change must be made on both sides simultaneously.**
+
+## Keys
+
+* Algorithm: Ed25519 (32-byte raw public key, SPKI-DER-wrapped PEM).
+* The desktop binary embeds the public key at build time via the
+  `HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM_DEFAULT` build env var.
+* The private key is held only as the `RUNTIME_SIGN_PRIVATE_KEY_PEM`
+  GitHub Actions secret — never written to disk in CI, never in source.
+
+### Current public key
+
+```
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAqPkLQ4o67G2GMTgkQQQZXWwDBZM/4hqq5thSZSNhoC0=
+-----END PUBLIC KEY-----
+```
+
+If you need to rotate, generate a new pair, swap both:
+
+* GitHub secret `RUNTIME_SIGN_PRIVATE_KEY_PEM` in this repo
+* Build env `HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM_DEFAULT` in the
+  hermes-cn-desktop-v2 release workflow
+
+Cut a new desktop release at the same time — older desktop builds carry
+the old key and will reject anything signed by the new one.
+
+## Cutting a release
+
+1. Tag the commit you want to ship:
+   ```
+   git tag runtime-v0.13.0
+   git push origin runtime-v0.13.0
+   ```
+2. The `release-runtime` workflow runs once per platform (Windows / macOS-arm64 / Linux-x64).
+3. Each job:
+   - Builds a self-contained executable via PyInstaller
+   - Smoke-tests it (`dashboard --help` must exit 0)
+   - Zips the dist directory as `hermes-agent-cn-runtime-<platform>-<arch>.zip`
+   - Signs the manifest with `scripts/sign_runtime_manifest.py`
+4. The aggregate `release` job downloads all artifacts and publishes
+   them to a GitHub Release named `runtime-v0.13.0`.
+
+Once the release exists, every hermes-cn-desktop-v2 install whose
+manifest URL points at this base URL will pick up the update on next
+launch (or via the in-app "check for updates" flow).
+
+## Manual dry run
+
+```
+$ pip install -e .
+$ pip install pyinstaller cryptography
+$ pyinstaller --noconfirm --name hermes-agent-cn-runtime-win32-x64 \
+    --onedir --console \
+    --collect-submodules hermes_cli --collect-submodules tui_gateway \
+    --paths . hermes_cli/main.py
+$ ./dist/hermes-agent-cn-runtime-win32-x64/hermes-agent-cn-runtime-win32-x64.exe dashboard --help
+$ # zip + sign manually using scripts/sign_runtime_manifest.py
+```
+
+## Known gaps
+
+* **Lazy provider deps** (`anthropic`, `firecrawl-py`, `exa-py`, ...) are
+  not bundled. `tools/lazy_deps.py` can't install at runtime inside a
+  PyInstaller-frozen binary, so only providers we explicitly pre-bake
+  are available. Add to the workflow's `--hidden-import` list as
+  needed.
+* **Code signing**: PyInstaller-produced Windows .exe is often flagged
+  by SmartScreen until signed with an Authenticode cert. Register one
+  and add the signing step to the workflow.
+* **Cross-arch builds**: x64-only for Linux today. Add arm64 matrix
+  entry once we have a runner.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -54,7 +54,7 @@ from gateway.status import get_running_pid, read_runtime_status
 try:
     from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
     from fastapi.middleware.cors import CORSMiddleware
-    from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
+    from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, PlainTextResponse, Response, StreamingResponse
     from fastapi.staticfiles import StaticFiles
     from pydantic import BaseModel
 except ImportError:
@@ -113,6 +113,10 @@ _PUBLIC_API_PATHS: frozenset = frozenset({
     "/api/dashboard/themes",
     "/api/dashboard/plugins",
     "/api/dashboard/plugins/rescan",
+    # P-009: EventSource can't set Authorization, so /api/v2/events
+    # authenticates the token from the query string inside the route
+    # handler itself. The handler still rejects 401 on mismatch.
+    "/api/v2/events",
 })
 
 
@@ -3586,6 +3590,179 @@ async def gateway_ws(ws: WebSocket) -> None:
     from tui_gateway.ws import handle_ws
 
     await handle_ws(ws)
+
+
+# ---------------------------------------------------------------------------
+# P-009: SSE+POST transport for clients that can't open a WebSocket to the
+# dashboard (Tauri webview can't cross from tauri:// to http://127.0.0.1
+# without a CORS-friendly upgrade path). Same dispatcher surface as
+# /api/ws — just split across a one-way SSE stream and one-shot POSTs.
+#
+# Wire protocol matches what `web/src/lib/gateway-sse-client.ts` in the
+# desktop project expects:
+#   GET /api/v2/events            — SSE stream
+#     query: token=<session token>   (no Authorization header on EventSource)
+#            client_id=<id> (optional — reuse an id across reconnects)
+#     emits: event: client_id\ndata: {"client_id": "<uuid>"}\n\n
+#            then JSON-RPC frames as `data: <json>\n\n` (the same
+#            frames /api/ws emits over the WebSocket — gateway.ready first,
+#            then per-method events).
+#     keepalive: `: ping\n\n` every 15s.
+#   POST /api/v2/rpc              — JSON-RPC request
+#     auth: Authorization: Bearer <token> (regular header path; this
+#           route is NOT public, the auth middleware handles it).
+#     header: X-Hermes-Client-Id: <id from /api/v2/events>
+#     body: {"jsonrpc": "2.0", "id": "...", "method": "...", "params": {...}}
+#     reply: inline JSON-RPC response, OR
+#            {"jsonrpc": "2.0", "id": "...", "result": {"accepted": true, "async": true}}
+#            when the handler ran on the worker pool — the real response
+#            arrives via the SSE stream.
+# ---------------------------------------------------------------------------
+
+
+@app.get("/api/v2/events")
+async def gateway_events(request: Request) -> Any:
+    # Token auth: EventSource can't set Authorization, so the token is on
+    # the query string. /api/v2/events is on _PUBLIC_API_PATHS exactly so
+    # the auth middleware doesn't 401 before we get a chance to check.
+    token = request.query_params.get("token", "")
+    if not hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
+        return PlainTextResponse("Unauthorized", status_code=401)
+
+    from tui_gateway import server as _gw_server
+    from tui_gateway.sse import SSE_CLIENTS, SSETransport, new_client_id
+
+    # Allow the client to propose an id (for resumption across reconnects).
+    # Reject if it collides with a live connection; otherwise generate fresh.
+    requested = (request.query_params.get("client_id") or "").strip()
+    if requested and requested not in SSE_CLIENTS and len(requested) <= 64:
+        client_id = requested
+    else:
+        client_id = new_client_id()
+
+    transport = SSETransport(client_id, asyncio.get_running_loop())
+    SSE_CLIENTS[client_id] = transport
+
+    # Mirror handle_ws: emit gateway.ready as the second frame (after the
+    # client_id handshake frame the stream prepends).
+    transport.write(
+        {
+            "jsonrpc": "2.0",
+            "method": "event",
+            "params": {
+                "type": "gateway.ready",
+                "payload": {"skin": _gw_server.resolve_skin()},
+            },
+        }
+    )
+
+    async def streamer():
+        try:
+            async for chunk in transport.stream():
+                yield chunk
+        finally:
+            transport.close()
+            SSE_CLIENTS.pop(client_id, None)
+            # Detach the transport from any sessions it owned so later
+            # emits fall back to stdio instead of crashing into a closed
+            # queue — same cleanup as ws.py:212-214.
+            for _sid, sess in list(_gw_server._sessions.items()):
+                if sess.get("transport") is transport:
+                    sess["transport"] = _gw_server._stdio_transport
+
+    return StreamingResponse(
+        streamer(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            # nginx and friends like to buffer text/event-stream into 4KB
+            # chunks; this header opts out so frames arrive as written.
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@app.post("/api/v2/rpc")
+async def gateway_rpc(request: Request) -> JSONResponse:
+    # Auth: regular header path, middleware already 401'd anyone without
+    # a valid token. This route is NOT on _PUBLIC_API_PATHS.
+
+    from tui_gateway import server as _gw_server
+    from tui_gateway.sse import SSE_CLIENTS
+
+    client_id = request.headers.get("x-hermes-client-id", "").strip()
+    if not client_id:
+        return JSONResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {
+                    "code": -32004,
+                    "message": "missing X-Hermes-Client-Id header; open /api/v2/events first",
+                },
+            },
+            status_code=400,
+        )
+
+    transport = SSE_CLIENTS.get(client_id)
+    if transport is None:
+        return JSONResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {
+                    "code": -32004,
+                    "message": "unknown client_id; reconnect /api/v2/events",
+                },
+            },
+            status_code=410,  # Gone — explicit "this id no longer exists"
+        )
+
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        return JSONResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": "parse error"},
+            },
+            status_code=400,
+        )
+
+    # Run dispatch in a worker thread so long handlers block the pool
+    # instead of the event loop — same pattern as ws.py:173. Any
+    # exception is caught and surfaced as a JSON-RPC error (mirroring
+    # the P-007 fix in ws.py:172-204) so the client sees a structured
+    # failure instead of a dropped connection.
+    try:
+        resp = await asyncio.to_thread(_gw_server.dispatch, body, transport)
+    except Exception as exc:
+        _log.exception("dispatch crashed for client %s", client_id)
+        return JSONResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": body.get("id") if isinstance(body, dict) else None,
+                "error": {
+                    "code": -32000,
+                    "message": f"dispatch crashed: {type(exc).__name__}: {exc}",
+                },
+            },
+            status_code=500,
+        )
+
+    if resp is None:
+        # Long handler — the pool worker will write the real response via
+        # the SSE transport. Acknowledge with the contract the SSE client
+        # checks for (gateway-sse-client.ts:67-74).
+        return JSONResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": body.get("id") if isinstance(body, dict) else None,
+                "result": {"accepted": True, "async": True},
+            }
+        )
+    return JSONResponse(resp)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/sign_runtime_manifest.py
+++ b/scripts/sign_runtime_manifest.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Sign a hermes-agent-cn runtime manifest with Ed25519.
+
+The hermes-cn-desktop-v2 client (see ``src/process/runtime.rs``) verifies
+the signature against the public key it was built with. The canonical
+payload concatenated with ``\\n`` matches what the Rust side reconstructs
+in ``signature_payload()`` — keep the field order in sync.
+
+Inputs are passed via flags so the GitHub Actions workflow can wire them
+up without env-var games. The private key is read from
+``RUNTIME_SIGN_PRIVATE_KEY_PEM`` (env) by default — never accept it on
+argv where it would land in process listings.
+
+Usage:
+    python scripts/sign_runtime_manifest.py \\
+        --channel stable \\
+        --version 0.13.0+cn.20260516 \\
+        --platform win32 \\
+        --arch x64 \\
+        --artifact-url https://github.com/.../runtime-win32-x64.zip \\
+        --artifact-path dist/runtime-win32-x64.zip \\
+        --upstream-repo Eynzof/hermes-agent-cn \\
+        --upstream-commit "$GITHUB_SHA" \\
+        --min-app-version 0.1.0 \\
+        --output dist/manifest-win32-x64.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime as _dt
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+try:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+except ImportError:
+    raise SystemExit(
+        "scripts/sign_runtime_manifest.py needs `cryptography` "
+        "(pip install cryptography)."
+    )
+
+
+# Field order MUST match `signature_payload()` in
+# hermes-cn-desktop-v2/src/process/runtime.rs. Any reorder here is a
+# silent verification failure on every desktop install — change both
+# sides together or not at all.
+_PAYLOAD_FIELDS = (
+    "channel",
+    "platform",
+    "arch",
+    "version",
+    "artifactUrl",
+    "sha256",
+    "upstreamRepo",
+    "upstreamCommit",
+)
+
+
+def _sha256_hex(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _load_private_key() -> Ed25519PrivateKey:
+    pem = os.environ.get("RUNTIME_SIGN_PRIVATE_KEY_PEM")
+    if not pem:
+        raise SystemExit(
+            "RUNTIME_SIGN_PRIVATE_KEY_PEM is not set. In GitHub Actions, wire "
+            "the repository secret to the workflow env block; locally, "
+            "export it from your encrypted key store. Never put the key on "
+            "argv (it'd leak via process listings)."
+        )
+    # Unwrap "\n" → newline so secrets pasted as one-liners work.
+    pem = pem.replace("\\n", "\n").encode()
+    key = load_pem_private_key(pem, password=None)
+    if not isinstance(key, Ed25519PrivateKey):
+        raise SystemExit("RUNTIME_SIGN_PRIVATE_KEY_PEM is not an Ed25519 key.")
+    return key
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--channel", required=True, help="stable | beta | canary | ...")
+    p.add_argument("--version", required=True)
+    p.add_argument("--platform", required=True, choices=("win32", "darwin", "linux"))
+    p.add_argument("--arch", required=True, choices=("x64", "arm64"))
+    p.add_argument("--artifact-url", required=True, help="HTTPS URL clients fetch")
+    p.add_argument(
+        "--artifact-path",
+        required=True,
+        type=Path,
+        help="Local path to the zip — used to compute sha256",
+    )
+    p.add_argument("--upstream-repo", required=True, help="org/name slug")
+    p.add_argument("--upstream-commit", required=True, help="commit SHA")
+    p.add_argument("--min-app-version", default=None, help="desktop client floor")
+    p.add_argument("--output", required=True, type=Path)
+    args = p.parse_args()
+
+    if not args.artifact_path.is_file():
+        raise SystemExit(f"artifact zip not found: {args.artifact_path}")
+
+    if not args.artifact_url.startswith("https://"):
+        # Rust side rejects non-https; fail fast here so CI doesn't ship
+        # a manifest the client will refuse.
+        raise SystemExit(f"artifact_url must be https:, got {args.artifact_url!r}")
+
+    sha256 = _sha256_hex(args.artifact_path)
+    print(f"sha256({args.artifact_path.name}) = {sha256}", file=sys.stderr)
+
+    manifest = {
+        "channel": args.channel,
+        "platform": args.platform,
+        "arch": args.arch,
+        "version": args.version,
+        "artifactUrl": args.artifact_url,
+        "sha256": sha256,
+        "upstreamRepo": args.upstream_repo,
+        "upstreamCommit": args.upstream_commit,
+    }
+    if args.min_app_version:
+        manifest["minAppVersion"] = args.min_app_version
+    manifest["createdAt"] = (
+        _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+
+    # Build canonical payload + sign. signature_payload() in runtime.rs
+    # concatenates these eight fields with \n separators.
+    payload = "\n".join(str(manifest[f]) for f in _PAYLOAD_FIELDS).encode()
+    key = _load_private_key()
+    signature = key.sign(payload)
+    manifest["signature"] = base64.standard_b64encode(signature).decode()
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tui_gateway/sse.py
+++ b/tui_gateway/sse.py
@@ -1,0 +1,154 @@
+"""SSE+POST transport for the tui_gateway JSON-RPC server (P-009).
+
+Mirrors :mod:`tui_gateway.ws` but split across two HTTP routes:
+
+* ``GET /api/v2/events`` — one-way Server-Sent Events stream the client
+  subscribes to once at start-up. The server emits a ``client_id`` frame
+  before anything else; the client carries that id on every subsequent
+  RPC POST so the server can route the response back to the right
+  stream.
+* ``POST /api/v2/rpc`` — one-shot JSON-RPC request. The route handler
+  looks up the client's :class:`SSETransport` by id, calls
+  :func:`tui_gateway.server.dispatch` with it bound, and either returns
+  the inline response or — for long handlers — returns a sentinel and
+  lets the pool worker push the real response via the SSE stream.
+
+Why SSE+POST instead of WS
+--------------------------
+Tauri webviews can't open ``ws://`` to localhost when the page is
+served via ``tauri://``; CORS rejects the upgrade. SSE works because
+EventSource is plain GET, and the desktop's Rust SSE proxy can
+forward the stream from the privileged side. The trade-off is that
+EventSource can't set custom headers, so the session token rides the
+query string and the route handler authenticates it directly (the
+path is on :data:`hermes_cli.web_server._PUBLIC_API_PATHS` so the
+middleware doesn't 401 it first).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from typing import AsyncIterator, Dict, Optional
+
+_log = logging.getLogger(__name__)
+
+# Max seconds an off-loop write will block waiting for the event loop
+# to enqueue the frame. Same role as ``_WS_WRITE_TIMEOUT_S`` in
+# tui_gateway.ws — protects pool workers from a wedged client.
+_SSE_WRITE_TIMEOUT_S = 10.0
+
+# Idle ping interval (seconds). Proxies (and the browser itself) close
+# idle EventSource connections after ~30-60s, so we emit a SSE comment
+# frame every interval.
+_SSE_PING_INTERVAL_S = 15.0
+
+# Bound the per-client queue to a sensible cap so a slow consumer can't
+# OOM the process. A misbehaving client gets a dropped frame and the
+# transport closes itself; the client will reconnect.
+_SSE_QUEUE_MAX = 1024
+
+
+class SSETransport:
+    """Per-SSE-connection transport.
+
+    Implements the :class:`tui_gateway.transport.Transport` protocol so
+    :func:`tui_gateway.server.dispatch` can write back through it the
+    same way it writes through :class:`tui_gateway.ws.WSTransport`.
+
+    ``write`` is callable from any thread; it marshals frames onto the
+    owning event loop via :func:`asyncio.run_coroutine_threadsafe` so
+    the SSE generator can pull them out in order.
+    """
+
+    __slots__ = ("client_id", "_loop", "_queue", "_closed")
+
+    def __init__(self, client_id: str, loop: asyncio.AbstractEventLoop) -> None:
+        self.client_id = client_id
+        self._loop = loop
+        self._queue: asyncio.Queue[Optional[str]] = asyncio.Queue(maxsize=_SSE_QUEUE_MAX)
+        self._closed = False
+
+    def write(self, obj: dict) -> bool:
+        if self._closed:
+            return False
+
+        # Serialize outside the loop coroutine so dict-encoding errors
+        # surface to the caller (a programming bug we want in the crash
+        # log, not a silent disconnect — see StdioTransport.write).
+        line = json.dumps(obj, ensure_ascii=False)
+
+        try:
+            on_loop = asyncio.get_running_loop() is self._loop
+        except RuntimeError:
+            on_loop = False
+
+        if on_loop:
+            try:
+                self._queue.put_nowait(line)
+                return True
+            except asyncio.QueueFull:
+                self._closed = True
+                _log.debug("sse queue full on loop; closing client %s", self.client_id)
+                return False
+
+        # Off-loop: marshal onto the loop. We use put() (not put_nowait)
+        # so back-pressure is honoured; if the loop is dead the
+        # run_coroutine_threadsafe future will time out and we close.
+        try:
+            fut = asyncio.run_coroutine_threadsafe(self._queue.put(line), self._loop)
+            fut.result(timeout=_SSE_WRITE_TIMEOUT_S)
+            return not self._closed
+        except Exception as exc:
+            self._closed = True
+            _log.debug("sse write failed: %s", exc)
+            return False
+
+    async def stream(self) -> AsyncIterator[str]:
+        """Yield SSE-framed text chunks until the transport closes.
+
+        The very first chunk is the ``client_id`` frame the client
+        needs to reach this transport via :func:`POST /api/v2/rpc`. The
+        gateway then yields whatever the dispatcher writes, plus a
+        ``: ping`` comment every :data:`_SSE_PING_INTERVAL_S` so idle
+        proxies don't drop the connection.
+        """
+        yield f"event: client_id\ndata: {json.dumps({'client_id': self.client_id})}\n\n"
+
+        while not self._closed:
+            try:
+                line = await asyncio.wait_for(
+                    self._queue.get(),
+                    timeout=_SSE_PING_INTERVAL_S,
+                )
+            except asyncio.TimeoutError:
+                yield ": ping\n\n"
+                continue
+            if line is None:
+                break
+            yield f"data: {line}\n\n"
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        # Drop a sentinel so the stream coroutine wakes and exits even
+        # if no frames are pending. Best-effort: if the loop is gone,
+        # nothing to wake.
+        try:
+            asyncio.run_coroutine_threadsafe(self._queue.put(None), self._loop)
+        except Exception:
+            pass
+
+
+# Registry of live SSE connections, keyed by client_id. Populated when
+# /api/v2/events opens a stream and removed on disconnect. POST /api/v2/rpc
+# looks up the transport here before calling dispatch().
+SSE_CLIENTS: Dict[str, SSETransport] = {}
+
+
+def new_client_id() -> str:
+    """Generate a fresh, opaque client id."""
+    return uuid.uuid4().hex


### PR DESCRIPTION
## Summary

桌面端（hermes-cn-desktop-v2）默认走 SSE transport，但上游 hermes-agent 里没有对应的 server 路由，UI 一连就报 "SSE closed during connect"。这个 PR 加上 P-009（服务端 SSE+POST）让桌面端能直接接通，外加配套的 runtime release CI/签名管线让桌面端能首启动自动下载这版 fork。

两个 commit：

### `01edd1399` feat(P-009): SSE+POST transport for tui_gateway

- `tui_gateway/sse.py`：新增 SSETransport（asyncio.Queue 后端、跨线程安全、15s ping、有界队列）+ SSE_CLIENTS 注册表
- `hermes_cli/web_server.py`：
  - `GET /api/v2/events`：SSE 流，token 走 query string（EventSource 不能加 header），发 client_id 握手 + gateway.ready，复用 ``tui_gateway.server.dispatch``
  - `POST /api/v2/rpc`：常规 Authorization Bearer，按 X-Hermes-Client-Id 查 SSE 客户端，丢到 worker pool 跑（mirrors ws.py:173）

线协议跟 /api/ws 完全一致（同样的 JSON-RPC envelope、同样的 event 帧、同样的 dispatch surface）。本地 curl 端到端验证 OK：client_id 握手 + gateway.ready + session.list 都正常。

### `a74fbc53f` ci: add runtime release pipeline (build + Ed25519 sign + publish)

- `scripts/sign_runtime_manifest.py`：Ed25519 签 manifest，字段顺序跟桌面端 `runtime.rs::signature_payload()` 严格对应
- `.github/workflows/release-runtime.yml`：tag (`runtime-v*`) 触发，三平台 matrix（win32-x64 / darwin-arm64 / linux-x64），PyInstaller 打包，smoke test (\`dashboard --help\`)，zip，签 manifest，发 GitHub Release
- `docs/RUNTIME_RELEASES.md`：线协议 schema、密钥轮转、手动 dry-run、known gaps

### Required secret

需要在仓库 secrets 里加：
- `RUNTIME_SIGN_PRIVATE_KEY_PEM` — Ed25519 PEM 私钥（公钥已在 docs/RUNTIME_RELEASES.md 文档化）

## Test plan

- [x] `tui_gateway/sse.py` 和 `hermes_cli/web_server.py` Python AST 解析通过
- [x] 本地装 patched 版本 + 跑 dashboard，curl 直连 9119 SSE 拿到 client_id + gateway.ready
- [x] curl POST /api/v2/rpc with session.list 返回真实会话列表
- [x] 走 Vite proxy（端口 9545）同样能 SSE 流式
- [x] Python cryptography 验证 sign_runtime_manifest.py 产物的 Ed25519 签名（对照桌面端 runtime.rs::verify_signature 的字节布局）
- [ ] CI matrix 实跑（待 tag）
- [ ] PyInstaller 打出的 binary 在 win32/darwin/linux 都能 \`hermes dashboard --help\`（待 CI）

Refs Eynzof/hermes-cn-desktop-v2#10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)