### PR TITLE
[codex] bundle anthropic sdk in runtime

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -14,10 +14,9 @@
 #
 # Caveats (track in follow-up issues, not blockers for first run):
 #   - PyInstaller's autodetection misses lazy-imported provider SDKs
-#     (anthropic, firecrawl-py, etc.). Add them to hidden-imports as the
-#     ecosystem grows. The agent's `tools/lazy_deps.py` install flow won't
-#     work inside a frozen binary anyway — only the providers we pre-bake
-#     are usable. That's acceptable for v1; revisit when users complain.
+#     (firecrawl-py, etc.). Add them to hidden-imports as the ecosystem
+#     grows. The agent's `tools/lazy_deps.py` install flow won't work inside
+#     a frozen binary anyway — only the providers we pre-bake are usable.
 #   - Antivirus on Windows occasionally flags PyInstaller output. Sign
 #     the .exe (Authenticode) once you've registered a code-signing cert.
 #     Until then, document the false-positive in the release notes.
@@ -115,7 +114,10 @@ jobs:
           # Install the package plus dashboard extras into the build env so the
           # frozen runtime never tries to lazy-install fastapi/uvicorn on a
           # user's machine.
-          pip install -e ".[web]"
+          # MiniMax-CN is wired through the Anthropic Messages transport.
+          # The SDK is intentionally lazy-imported in normal pip installs, so
+          # the frozen runtime must install and collect it explicitly.
+          pip install -e ".[web,anthropic]"
           # Build tooling
           pip install pyinstaller==6.* cryptography
 
@@ -137,6 +139,7 @@ jobs:
             --collect-submodules starlette \
             --collect-submodules uvicorn \
             --collect-submodules pydantic \
+            --collect-submodules anthropic \
             --collect-data hermes_cli \
             --collect-data gateway \
             --collect-data plugins \
@@ -149,10 +152,22 @@ jobs:
             --copy-metadata starlette \
             --copy-metadata uvicorn \
             --copy-metadata pydantic \
+            --copy-metadata anthropic \
             --paths . \
             -p . \
             hermes_cli/main.py
           ls -la "dist/$NAME"
+
+      - name: Verify frozen provider SDKs
+        shell: bash
+        run: |
+          NAME="hermes-agent-cn-runtime-${{ matrix.platform }}-${{ matrix.arch }}"
+          metadata_dir="$(find "dist/$NAME/_internal" -maxdepth 1 -type d -name 'anthropic-*.dist-info' -print -quit)"
+          if [[ -z "$metadata_dir" ]]; then
+            echo "Frozen runtime is missing anthropic package metadata" >&2
+            find "dist/$NAME" -maxdepth 3 -type d -name 'anthropic*' -print >&2
+            exit 1
+          fi
 
       - name: Smoke-test the binary
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
 [project.optional-dependencies]
 # Native Anthropic provider — only needed when provider=anthropic (not via
 # OpenRouter or other aggregators).
-anthropic = ["anthropic==0.86.0"]
+anthropic = ["anthropic==0.87.0"]
 # Web search backends — each only loaded when the user picks it as their
 # search provider (configured via `hermes tools` or config.yaml).
 exa = ["exa-py==2.10.2"]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,8 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    # fork maintainers
+    "eynzof@gmail.com": "Eynzof",
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
     "30366221+WorldWriter@users.noreply.github.com": "WorldWriter",

--- a/tests/test_runtime_release_workflow.py
+++ b/tests/test_runtime_release_workflow.py
@@ -1,0 +1,24 @@
+"""Regression tests for the signed desktop runtime release workflow."""
+
+from pathlib import Path
+
+
+def _workflow_text() -> str:
+    workflow = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release-runtime.yml"
+    return workflow.read_text(encoding="utf-8")
+
+
+def test_runtime_workflow_freezes_anthropic_sdk_for_minimax_cn():
+    """MiniMax-CN uses the Anthropic Messages transport in the desktop runtime.
+
+    The runtime is a frozen PyInstaller executable, so lazy-installing the
+    provider SDK at first use cannot work there. The release workflow must
+    eagerly install and collect the Anthropic SDK, otherwise desktop users get
+    an import failure before MiniMax-CN can make its first request.
+    """
+    workflow = _workflow_text()
+
+    assert 'pip install -e ".[web,anthropic]"' in workflow
+    assert "--collect-submodules anthropic" in workflow
+    assert "--copy-metadata anthropic" in workflow
+    assert "anthropic-*.dist-info" in workflow

--- a/uv.lock
+++ b/uv.lock
@@ -321,7 +321,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.86.0"
+version = "0.87.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -333,9 +333,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/7a/8b390dc47945d3169875d342847431e5f7d5fa716b2e37494d57cfc1db10/anthropic-0.86.0.tar.gz", hash = "sha256:60023a7e879aa4fbb1fed99d487fe407b2ebf6569603e5047cfe304cebdaa0e5", size = 583820, upload-time = "2026-03-18T18:43:08.017Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/8f/3281edf7c35cbac169810e5388eb9b38678c7ea9867c2d331237bd5dff08/anthropic-0.87.0.tar.gz", hash = "sha256:098fef3753cdd3c0daa86f95efb9c8d03a798d45c5170329525bb4653f6702d0", size = 588982, upload-time = "2026-03-31T17:52:41.697Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/5f/67db29c6e5d16c8c9c4652d3efb934d89cb750cad201539141781d8eae14/anthropic-0.86.0-py3-none-any.whl", hash = "sha256:9d2bbd339446acce98858c5627d33056efe01f70435b22b63546fe7edae0cd57", size = 469400, upload-time = "2026-03-18T18:43:06.526Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/02/99bf351933bdea0545a2b6e2d812ed878899e9a95f618351dfa3d0de0e69/anthropic-0.87.0-py3-none-any.whl", hash = "sha256:e2669b86d42c739d3df163f873c51719552e263a3d85179297180fb4fa00a236", size = 472126, upload-time = "2026-03-31T17:52:40.174Z" },
 ]
 
 [[package]]
@@ -1797,7 +1797,7 @@ requires-dist = [
     { name = "aiohttp-socks", marker = "extra == 'matrix'", specifier = "==0.11.0" },
     { name = "aiosqlite", marker = "extra == 'matrix'", specifier = "==0.22.1" },
     { name = "alibabacloud-dingtalk", marker = "extra == 'dingtalk'", specifier = "==2.2.42" },
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = "==0.86.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = "==0.87.0" },
     { name = "asyncpg", marker = "extra == 'matrix'", specifier = "==0.31.0" },
     { name = "azure-identity", marker = "extra == 'azure-identity'", specifier = "==1.25.3" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = "==1.42.89" },


### PR DESCRIPTION
## Summary

Fix the signed desktop runtime build so MiniMax-CN can use the Anthropic Messages transport inside the frozen PyInstaller executable.

## Root cause

MiniMax-CN is configured to call the Anthropic-compatible endpoint at `https://api.minimaxi.com/anthropic`, so runtime startup needs the `anthropic` Python SDK. The normal pip install path lazy-installs that SDK, but the desktop managed runtime is a frozen PyInstaller bundle, where lazy installation cannot repair missing modules.

## Changes

- Install the runtime build environment with `.[web,anthropic]` instead of only `.[web]`.
- Explicitly collect Anthropic SDK submodules and package metadata in PyInstaller.
- Add a frozen-runtime verification step that fails if Anthropic metadata is missing.
- Align the `anthropic` optional extra with the existing lazy-deps pin at `0.87.0` and refresh `uv.lock`.
- Add a regression test that locks the release workflow contract.

## Related

Fixes the runtime side of Eynzof/hermes-agent-cn-desktop#7.

## Test Plan

- `uv lock --check`
- `git diff --check`
- `scripts/run_tests.sh tests/test_project_metadata.py tests/tools/test_lazy_deps.py tests/test_runtime_release_workflow.py`
