### PR TITLE
fix: sign notarizable macOS runtime payloads

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -6,11 +6,13 @@
 # zip it, sign the manifest with Ed25519, and attach all artifacts to a
 # GitHub Release.
 #
-# Required repository secret:
+# Required repository secrets:
 #   RUNTIME_SIGN_PRIVATE_KEY_PEM
 #     The Ed25519 PEM-encoded private key. The matching public key is
 #     baked into the desktop binary via the HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM_DEFAULT
 #     env var at build time. See docs/RUNTIME_RELEASES.md.
+#   APPLE_CERTIFICATE / APPLE_CERTIFICATE_PASSWORD / APPLE_SIGNING_IDENTITY
+#     Developer ID Application signing material for macOS runtime payloads.
 #
 # Caveats (track in follow-up issues, not blockers for first run):
 #   - PyInstaller's autodetection misses lazy-imported provider SDKs
@@ -158,6 +160,57 @@ jobs:
             hermes_cli/main.py
           ls -la "dist/$NAME"
 
+      - name: Normalize macOS framework layout
+        if: matrix.platform == 'darwin'
+        shell: bash
+        run: |
+          NAME="hermes-agent-cn-runtime-${{ matrix.platform }}-${{ matrix.arch }}"
+          python scripts/normalize_macos_pyinstaller_runtime.py "dist/$NAME"
+
+      - name: Prepare macOS signing credentials
+        if: matrix.platform == 'darwin'
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          test -n "$APPLE_CERTIFICATE"
+          test -n "$APPLE_CERTIFICATE_PASSWORD"
+          test -n "$APPLE_SIGNING_IDENTITY"
+
+          signing_keychain_password="$(uuidgen)"
+          signing_keychain="$RUNNER_TEMP/hermes-runtime-signing.keychain-db"
+          certificate_path="$RUNNER_TEMP/hermes-runtime-apple-certificate.p12"
+
+          security create-keychain -p "$signing_keychain_password" "$signing_keychain"
+          security set-keychain-settings -lut 21600 "$signing_keychain"
+          security unlock-keychain -p "$signing_keychain_password" "$signing_keychain"
+
+          printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$certificate_path"
+          security import "$certificate_path" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$signing_keychain"
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "$signing_keychain_password" \
+            "$signing_keychain"
+          security list-keychains -d user -s "$signing_keychain" $(security list-keychains -d user | tr -d '"')
+          security find-identity -v -p codesigning "$signing_keychain"
+
+      - name: Sign macOS runtime payload
+        if: matrix.platform == 'darwin'
+        shell: bash
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          NAME="hermes-agent-cn-runtime-${{ matrix.platform }}-${{ matrix.arch }}"
+          scripts/sign_macos_runtime_payload.sh "dist/$NAME"
+
       - name: Verify frozen provider SDKs
         shell: bash
         run: |
@@ -183,6 +236,10 @@ jobs:
           if [[ "${{ matrix.platform }}" == "win32" ]]; then
             # PowerShell Compress-Archive on Windows runner
             powershell -Command "Compress-Archive -Path dist/$NAME/* -DestinationPath out/$NAME.zip -Force"
+          elif [[ "${{ matrix.platform }}" == "darwin" ]]; then
+            # Preserve framework symlinks. Without -y, Info-ZIP stores the
+            # symlink targets as duplicate files and breaks codesign/notary.
+            (cd dist && zip -r -y "../out/$NAME.zip" "$NAME")
           else
             (cd dist && zip -r "../out/$NAME.zip" "$NAME")
           fi

--- a/docs/RUNTIME_RELEASES.md
+++ b/docs/RUNTIME_RELEASES.md
@@ -85,6 +85,13 @@ If you need to rotate, generate a new pair, swap both:
 * Build env `HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM_DEFAULT` in the
   hermes-cn-desktop-v2 release workflow
 
+macOS runtime releases also require the same Apple Developer ID signing
+secrets used by the desktop release workflow:
+
+* `APPLE_CERTIFICATE` — base64-encoded Developer ID Application `.p12`
+* `APPLE_CERTIFICATE_PASSWORD`
+* `APPLE_SIGNING_IDENTITY` — for example `Developer ID Application: ...`
+
 Cut a new desktop release at the same time — older desktop builds carry
 the old key and will reject anything signed by the new one.
 
@@ -99,8 +106,12 @@ the old key and will reject anything signed by the new one.
 3. The `release-runtime` workflow validates the tag against `pyproject.toml` and runs once per platform (Windows / macOS-arm64 / Linux-x64).
 4. Each job:
    - Builds a self-contained executable via PyInstaller
+   - On macOS, normalizes PyInstaller-collected `.framework` directories back
+     into standard symlink framework layouts
+   - On macOS, signs the full runtime payload with Developer ID before packaging
    - Smoke-tests it (`dashboard --help` must exit 0)
    - Zips the dist directory as `hermes-agent-cn-runtime-<platform>-<arch>.zip`
+     and preserves symlinks for macOS artifacts
    - Signs the manifest with `scripts/sign_runtime_manifest.py`
 5. The aggregate `release` job downloads all artifacts and publishes
    them to a GitHub Release named `runtime-v0.14.0-cn.1`.
@@ -125,6 +136,15 @@ $ ./dist/hermes-agent-cn-runtime-win32-x64/hermes-agent-cn-runtime-win32-x64.exe
 $ # zip + sign manually using scripts/sign_runtime_manifest.py
 ```
 
+For a macOS dry run after PyInstaller has produced `dist/hermes-agent-cn-runtime-darwin-arm64`:
+
+```bash
+$ python scripts/normalize_macos_pyinstaller_runtime.py dist/hermes-agent-cn-runtime-darwin-arm64
+$ APPLE_SIGNING_IDENTITY="Developer ID Application: ..." \
+    scripts/sign_macos_runtime_payload.sh dist/hermes-agent-cn-runtime-darwin-arm64
+$ (cd dist && zip -r -y ../out/hermes-agent-cn-runtime-darwin-arm64.zip hermes-agent-cn-runtime-darwin-arm64)
+```
+
 ## Known gaps
 
 * **Dashboard deps are bundled**: runtime artifacts must install `.[web]` and
@@ -135,8 +155,9 @@ $ # zip + sign manually using scripts/sign_runtime_manifest.py
   PyInstaller-frozen binary, so only providers we explicitly pre-bake
   are available. Add to the workflow's `--hidden-import` list as
   needed.
-* **Code signing**: PyInstaller-produced Windows .exe is often flagged
-  by SmartScreen until signed with an Authenticode cert. Register one
-  and add the signing step to the workflow.
+* **Code signing**: macOS runtime payloads are Developer ID signed in CI before
+  they are zipped. PyInstaller-produced Windows `.exe` files are still often
+  flagged by SmartScreen until signed with an Authenticode cert. Register one
+  and add the Windows signing step to the workflow.
 * **Cross-arch builds**: x64-only for Linux today. Add arm64 matrix
   entry once we have a runner.

--- a/docs/RUNTIME_VERSIONING.md
+++ b/docs/RUNTIME_VERSIONING.md
@@ -106,7 +106,8 @@ Any change to that order must be made in both
    ```
 
 4. The `release-runtime` workflow validates that the tag's `kernelVersion`
-   matches `pyproject.toml`, builds the platform runtimes, writes schema v2
-   manifests, signs them, and publishes all assets to the GitHub Release.
+   matches `pyproject.toml`, builds the platform runtimes, normalizes and
+   Developer ID signs the macOS payload, writes schema v2 manifests, signs
+   them, and publishes all assets to the GitHub Release.
 
 Do not reuse a tag for a rebuilt runtime. Publish a new `cn.N` revision instead.

--- a/scripts/normalize_macos_pyinstaller_runtime.py
+++ b/scripts/normalize_macos_pyinstaller_runtime.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Normalize PyInstaller-collected macOS frameworks for code signing.
+
+PyInstaller can collect Python.framework into an onedir payload as a copied
+framework-shaped directory instead of the standard symlink layout. Apple
+codesign/notary then treats the duplicated ``Python.framework/Python`` and
+``Versions/Current`` directories as a bundle but cannot validate the resource
+seal, producing errors such as::
+
+    code has no resources but signature indicates they must be present
+
+This script rewrites those copied framework layouts back into the canonical
+macOS framework symlink form before signing and zipping the runtime artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+from pathlib import Path
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def _replace_with_symlink(path: Path, target: str) -> None:
+    _remove_path(path)
+    os.symlink(target, path)
+
+
+def _framework_version_dir(framework: Path) -> Path | None:
+    versions = framework / "Versions"
+    if not versions.is_dir():
+        return None
+    candidates = [
+        child
+        for child in versions.iterdir()
+        if child.is_dir() and not child.is_symlink() and child.name != "Current"
+    ]
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+    # Prefer Python-style numeric versions when there are auxiliary directories.
+    numeric = [child for child in candidates if child.name[:1].isdigit()]
+    if len(numeric) == 1:
+        return numeric[0]
+    names = ", ".join(sorted(child.name for child in candidates))
+    raise RuntimeError(f"{framework} has multiple framework version directories: {names}")
+
+
+def normalize_framework(framework: Path) -> bool:
+    version_dir = _framework_version_dir(framework)
+    if version_dir is None:
+        return False
+
+    executable_name = framework.stem
+    executable = version_dir / executable_name
+    resources = version_dir / "Resources"
+    if not executable.exists():
+        return False
+
+    _replace_with_symlink(framework / executable_name, f"Versions/Current/{executable_name}")
+    if resources.exists():
+        _replace_with_symlink(framework / "Resources", "Versions/Current/Resources")
+    else:
+        _remove_path(framework / "Resources")
+
+    _replace_with_symlink(framework / "Versions" / "Current", version_dir.name)
+    return True
+
+
+def normalize_runtime(root: Path) -> int:
+    normalized = 0
+    for framework in sorted(root.rglob("*.framework")):
+        if normalize_framework(framework):
+            normalized += 1
+    return normalized
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("runtime_dir", type=Path, help="PyInstaller onedir runtime directory")
+    args = parser.parse_args()
+
+    runtime_dir = args.runtime_dir
+    if not runtime_dir.is_dir():
+        raise SystemExit(f"runtime directory not found: {runtime_dir}")
+
+    normalized = normalize_runtime(runtime_dir)
+    print(f"normalized {normalized} macOS framework directories under {runtime_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sign_macos_runtime_payload.sh
+++ b/scripts/sign_macos_runtime_payload.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runtime_dir="${1:?usage: scripts/sign_macos_runtime_payload.sh <runtime-dir>}"
+identity="${APPLE_SIGNING_IDENTITY:-}"
+
+if [[ ! -d "$runtime_dir" ]]; then
+  echo "macOS runtime payload not found: $runtime_dir" >&2
+  exit 1
+fi
+
+if [[ -z "$identity" ]]; then
+  identity="$(
+    security find-identity -v -p codesigning 2>/dev/null \
+      | sed -n 's/.*"\(Developer ID Application:[^"]*\)".*/\1/p' \
+      | head -n 1
+  )"
+fi
+
+if [[ -z "$identity" ]]; then
+  echo "APPLE_SIGNING_IDENTITY is empty and no Developer ID Application identity was found" >&2
+  exit 1
+fi
+
+sign_args=(--force --sign "$identity")
+if [[ "$identity" != "-" ]]; then
+  sign_args+=(--timestamp --options runtime)
+fi
+
+is_macho() {
+  file "$1" | grep -q 'Mach-O'
+}
+
+inside_framework() {
+  [[ "$1" == *".framework/"* ]]
+}
+
+sign_path() {
+  local path="$1"
+  codesign "${sign_args[@]}" "$path"
+}
+
+verify_path() {
+  local path="$1"
+  codesign --verify --strict --verbose=2 "$path"
+}
+
+echo "Signing macOS runtime payload with identity: $identity"
+echo "Runtime payload: $runtime_dir"
+
+macho_count=0
+while IFS= read -r -d '' path; do
+  if inside_framework "$path"; then
+    continue
+  fi
+  if is_macho "$path"; then
+    sign_path "$path"
+    macho_count=$((macho_count + 1))
+  fi
+done < <(find "$runtime_dir" -type f -print0)
+
+echo "Signed $macho_count non-framework Mach-O files."
+
+framework_count=0
+while IFS= read -r -d '' framework; do
+  sign_path "$framework"
+  framework_count=$((framework_count + 1))
+done < <(find "$runtime_dir" -type d -name '*.framework' -print0 | sort -z -r)
+
+echo "Signed $framework_count framework bundles."
+
+while IFS= read -r -d '' framework; do
+  verify_path "$framework"
+done < <(find "$runtime_dir" -type d -name '*.framework' -print0 | sort -z)
+
+while IFS= read -r -d '' path; do
+  if is_macho "$path"; then
+    verify_path "$path"
+  fi
+done < <(find "$runtime_dir" -type f -print0)
+
+echo "macOS runtime payload signing verification passed."

--- a/tests/scripts/test_normalize_macos_pyinstaller_runtime.py
+++ b/tests/scripts/test_normalize_macos_pyinstaller_runtime.py
@@ -1,0 +1,47 @@
+"""Tests for macOS PyInstaller runtime framework normalization."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "normalize_macos_pyinstaller_runtime.py"
+)
+_SPEC = importlib.util.spec_from_file_location("normalize_macos_pyinstaller_runtime", _SCRIPT_PATH)
+assert _SPEC is not None
+_module = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_module)
+
+
+def test_normalize_runtime_replaces_copied_python_framework_layout(tmp_path: Path):
+    runtime = tmp_path / "runtime"
+    framework = runtime / "_internal" / "Python.framework"
+    version = framework / "Versions" / "3.11"
+    copied_current = framework / "Versions" / "Current"
+
+    (framework / "Resources").mkdir(parents=True)
+    (framework / "Python").write_bytes(b"top-level duplicate")
+    (framework / "Resources" / "Info.plist").write_bytes(b"top-level plist duplicate")
+    (version / "Resources").mkdir(parents=True)
+    (version / "Python").write_bytes(b"real python dylib")
+    (version / "Resources" / "Info.plist").write_bytes(b"real plist")
+    (copied_current / "Resources").mkdir(parents=True)
+    (copied_current / "Python").write_bytes(b"current duplicate")
+    (copied_current / "Resources" / "Info.plist").write_bytes(b"current plist duplicate")
+
+    assert _module.normalize_runtime(runtime) == 1
+
+    assert (framework / "Python").is_symlink()
+    assert os.readlink(framework / "Python") == "Versions/Current/Python"
+    assert (framework / "Resources").is_symlink()
+    assert os.readlink(framework / "Resources") == "Versions/Current/Resources"
+    assert (framework / "Versions" / "Current").is_symlink()
+    assert os.readlink(framework / "Versions" / "Current") == "3.11"
+    assert (framework / "Versions" / "3.11" / "Python").read_bytes() == b"real python dylib"
+    assert (
+        framework / "Versions" / "3.11" / "Resources" / "Info.plist"
+    ).read_bytes() == b"real plist"

--- a/tests/test_runtime_release_workflow.py
+++ b/tests/test_runtime_release_workflow.py
@@ -22,3 +22,13 @@ def test_runtime_workflow_freezes_anthropic_sdk_for_minimax_cn():
     assert "--collect-submodules anthropic" in workflow
     assert "--copy-metadata anthropic" in workflow
     assert "anthropic-*.dist-info" in workflow
+
+
+def test_runtime_workflow_signs_and_preserves_macos_frameworks():
+    workflow = _workflow_text()
+
+    assert "Normalize macOS framework layout" in workflow
+    assert "scripts/normalize_macos_pyinstaller_runtime.py" in workflow
+    assert "Prepare macOS signing credentials" in workflow
+    assert "scripts/sign_macos_runtime_payload.sh" in workflow
+    assert "zip -r -y" in workflow


### PR DESCRIPTION
## Summary
- normalize PyInstaller-collected macOS `.framework` directories back to standard symlink framework layout before signing
- import Developer ID signing credentials in the runtime release workflow and sign the full macOS runtime payload before zipping
- preserve macOS framework symlinks with `zip -r -y` so the published runtime artifact remains notarization-friendly
- add regression coverage for the workflow and framework normalization helper

## Verification
- `python -m py_compile scripts/normalize_macos_pyinstaller_runtime.py`
- `bash -n scripts/sign_macos_runtime_payload.sh`
- parsed `.github/workflows/release-runtime.yml` as YAML
- local end-to-end artifact test using current `runtime-v0.14.0-cn.3` darwin zip: normalized `Python.framework`, signed runtime payload, zipped with `zip -r -y`, unzipped, verified framework aliases with `codesign --verify --strict`, and ran `dashboard --help` from the re-zipped runtime
- `.venv/bin/python -m ruff check scripts/normalize_macos_pyinstaller_runtime.py tests/scripts/test_normalize_macos_pyinstaller_runtime.py tests/test_runtime_release_workflow.py`
- `scripts/run_tests.sh tests/test_runtime_release_workflow.py tests/scripts/test_normalize_macos_pyinstaller_runtime.py`