### PR TITLE
[codex] 扩展数据分析接口

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7713,7 +7713,7 @@ async def update_config_raw(body: RawConfigUpdate):
 
 
 # ---------------------------------------------------------------------------
-# Token / cost analytics endpoint
+# Token analytics endpoint
 # ---------------------------------------------------------------------------
 
 
@@ -7724,46 +7724,84 @@ async def get_usage_analytics(days: int = 30):
 
     db = SessionDB()
     try:
-        cutoff = time.time() - (days * 86400)
+        now = time.time()
+        window_seconds = days * 86400
+        cutoff = now - window_seconds
+        previous_cutoff = now - (window_seconds * 2)
+
+        def _totals(start_ts: float, end_ts: float) -> dict:
+            row = db._conn.execute("""
+                SELECT COALESCE(SUM(input_tokens), 0) as total_input,
+                       COALESCE(SUM(output_tokens), 0) as total_output,
+                       COALESCE(SUM(cache_read_tokens), 0) as total_cache_read,
+                       COALESCE(SUM(cache_write_tokens), 0) as total_cache_write,
+                       COALESCE(SUM(reasoning_tokens), 0) as total_reasoning,
+                       COUNT(*) as total_sessions,
+                       COALESCE(SUM(COALESCE(api_call_count, 0)), 0) as total_api_calls
+                FROM sessions WHERE started_at > ? AND started_at <= ?
+            """, (start_ts, end_ts)).fetchone()
+            totals = dict(row)
+            total_tokens = int(totals.get("total_input") or 0) + int(totals.get("total_output") or 0)
+            total_sessions = int(totals.get("total_sessions") or 0)
+            totals["total_tokens"] = total_tokens
+            totals["avg_tokens_per_session"] = (
+                total_tokens / total_sessions if total_sessions else 0
+            )
+            return totals
+
         cur = db._conn.execute("""
             SELECT date(started_at, 'unixepoch') as day,
-                   SUM(input_tokens) as input_tokens,
-                   SUM(output_tokens) as output_tokens,
-                   SUM(cache_read_tokens) as cache_read_tokens,
-                   SUM(reasoning_tokens) as reasoning_tokens,
-                   COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
-                   COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
+                   COALESCE(SUM(input_tokens), 0) as input_tokens,
+                   COALESCE(SUM(output_tokens), 0) as output_tokens,
+                   COALESCE(SUM(cache_read_tokens), 0) as cache_read_tokens,
+                   COALESCE(SUM(cache_write_tokens), 0) as cache_write_tokens,
+                   COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens,
                    COUNT(*) as sessions,
-                   SUM(COALESCE(api_call_count, 0)) as api_calls
-            FROM sessions WHERE started_at > ?
+                   COALESCE(SUM(COALESCE(api_call_count, 0)), 0) as api_calls
+            FROM sessions WHERE started_at > ? AND started_at <= ?
             GROUP BY day ORDER BY day
-        """, (cutoff,))
+        """, (cutoff, now))
         daily = [dict(r) for r in cur.fetchall()]
 
         cur2 = db._conn.execute("""
             SELECT model,
-                   SUM(input_tokens) as input_tokens,
-                   SUM(output_tokens) as output_tokens,
-                   COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
+                   COALESCE(billing_provider, '') as provider,
+                   COALESCE(SUM(input_tokens), 0) as input_tokens,
+                   COALESCE(SUM(output_tokens), 0) as output_tokens,
+                   COALESCE(SUM(cache_read_tokens), 0) as cache_read_tokens,
+                   COALESCE(SUM(cache_write_tokens), 0) as cache_write_tokens,
+                   COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens,
                    COUNT(*) as sessions,
-                   SUM(COALESCE(api_call_count, 0)) as api_calls
-            FROM sessions WHERE started_at > ? AND model IS NOT NULL
-            GROUP BY model ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
-        """, (cutoff,))
+                   COALESCE(SUM(COALESCE(api_call_count, 0)), 0) as api_calls
+            FROM sessions WHERE started_at > ? AND started_at <= ? AND model IS NOT NULL AND model != ''
+            GROUP BY model, billing_provider ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
+        """, (cutoff, now))
         by_model = [dict(r) for r in cur2.fetchall()]
 
+        totals = _totals(cutoff, now)
+
         cur3 = db._conn.execute("""
-            SELECT SUM(input_tokens) as total_input,
-                   SUM(output_tokens) as total_output,
-                   SUM(cache_read_tokens) as total_cache_read,
-                   SUM(reasoning_tokens) as total_reasoning,
-                   COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
-                   COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
-                   COUNT(*) as total_sessions,
-                   SUM(COALESCE(api_call_count, 0)) as total_api_calls
-            FROM sessions WHERE started_at > ?
-        """, (cutoff,))
-        totals = dict(cur3.fetchone())
+            SELECT id as session_id,
+                   title,
+                   model,
+                   COALESCE(billing_provider, '') as provider,
+                   started_at,
+                   ended_at,
+                   COALESCE(input_tokens, 0) as input_tokens,
+                   COALESCE(output_tokens, 0) as output_tokens,
+                   COALESCE(cache_read_tokens, 0) as cache_read_tokens,
+                   COALESCE(cache_write_tokens, 0) as cache_write_tokens,
+                   COALESCE(reasoning_tokens, 0) as reasoning_tokens,
+                   COALESCE(api_call_count, 0) as api_calls
+            FROM sessions
+            WHERE started_at > ? AND started_at <= ?
+            ORDER BY COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0) DESC,
+                     COALESCE(api_call_count, 0) DESC,
+                     started_at DESC
+            LIMIT 200
+        """, (cutoff, now))
+        top_sessions = [dict(r) for r in cur3.fetchall()]
+
         insights_report = InsightsEngine(db).generate(days=days)
         skills = insights_report.get("skills", {
             "summary": {
@@ -7778,7 +7816,11 @@ async def get_usage_analytics(days: int = 30):
         return {
             "daily": daily,
             "by_model": by_model,
+            "top_sessions": top_sessions,
             "totals": totals,
+            "comparison": {
+                "previous_totals": _totals(previous_cutoff, cutoff),
+            },
             "period_days": days,
             "skills": skills,
         }

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2315,11 +2315,19 @@ class TestNewEndpoints:
         data = resp.json()
         assert "daily" in data
         assert "by_model" in data
+        assert "top_sessions" in data
         assert "totals" in data
+        assert "comparison" in data
+        assert data["period_days"] == 7
         assert "skills" in data
         assert isinstance(data["daily"], list)
         assert "total_sessions" in data["totals"]
+        assert "total_tokens" in data["totals"]
+        assert "avg_tokens_per_session" in data["totals"]
         assert "total_api_calls" in data["totals"]
+        assert "total_cache_write" in data["totals"]
+        assert "total_effective_cost" not in data["totals"]
+        assert "previous_totals" in data["comparison"]
         assert data["skills"] == {
             "summary": {
                 "total_skill_loads": 0,
@@ -2329,6 +2337,100 @@ class TestNewEndpoints:
             },
             "top_skills": [],
         }
+
+    def test_analytics_usage_extended_contract_without_costs(self):
+        import time as _time
+
+        from hermes_state import SessionDB
+
+        now = _time.time()
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="analytics-api-heavy",
+                source="cli",
+                model="anthropic/claude-sonnet-4",
+            )
+            db.update_token_counts(
+                "analytics-api-heavy",
+                input_tokens=1000,
+                output_tokens=500,
+                model="anthropic/claude-sonnet-4",
+                cache_read_tokens=50,
+                cache_write_tokens=10,
+                reasoning_tokens=25,
+                billing_provider="anthropic",
+                api_call_count=3,
+            )
+            db.create_session(
+                session_id="analytics-token-heavy",
+                source="cli",
+                model="openai/gpt-4.1",
+            )
+            db.update_token_counts(
+                "analytics-token-heavy",
+                input_tokens=5000,
+                output_tokens=1000,
+                model="openai/gpt-4.1",
+                billing_provider="openai",
+                api_call_count=2,
+            )
+            db.create_session(
+                session_id="analytics-previous-window",
+                source="cli",
+                model="anthropic/claude-sonnet-4",
+            )
+            db.update_token_counts(
+                "analytics-previous-window",
+                input_tokens=100,
+                output_tokens=50,
+                model="anthropic/claude-sonnet-4",
+                billing_provider="anthropic",
+                api_call_count=1,
+            )
+
+            def _move_session(session_id: str, started_at: float, title: str) -> None:
+                def _do(conn):
+                    conn.execute(
+                        "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+                        (started_at, title, session_id),
+                    )
+                db._execute_write(_do)
+
+            _move_session("analytics-api-heavy", now - 3600, "API heavy")
+            _move_session("analytics-token-heavy", now - 7200, "Token heavy")
+            _move_session("analytics-previous-window", now - 8 * 86400, "Previous")
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/analytics/usage?days=7")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert data["totals"]["total_tokens"] == 7500
+        assert data["totals"]["total_sessions"] == 2
+        assert data["totals"]["total_api_calls"] == 5
+        assert data["totals"]["total_cache_read"] == 50
+        assert data["totals"]["total_cache_write"] == 10
+        assert "total_estimated_cost" not in data["totals"]
+        assert "total_actual_cost" not in data["totals"]
+        assert "total_effective_cost" not in data["totals"]
+        assert "currency" not in data
+        assert data["comparison"]["previous_totals"]["total_tokens"] == 150
+        assert data["comparison"]["previous_totals"]["total_sessions"] == 1
+
+        model_rows = {(row["provider"], row["model"]): row for row in data["by_model"]}
+        assert "actual_cost" not in model_rows[("anthropic", "anthropic/claude-sonnet-4")]
+        assert "estimated_cost" not in model_rows[("anthropic", "anthropic/claude-sonnet-4")]
+        assert "effective_cost" not in model_rows[("anthropic", "anthropic/claude-sonnet-4")]
+        assert model_rows[("anthropic", "anthropic/claude-sonnet-4")]["cache_read_tokens"] == 50
+        assert model_rows[("anthropic", "anthropic/claude-sonnet-4")]["cache_write_tokens"] == 10
+        assert model_rows[("openai", "openai/gpt-4.1")]["input_tokens"] == 5000
+
+        assert data["top_sessions"][0]["session_id"] == "analytics-token-heavy"
+        assert data["top_sessions"][0]["title"] == "Token heavy"
+        assert data["top_sessions"][1]["session_id"] == "analytics-api-heavy"
+        assert "effective_cost" not in data["top_sessions"][0]
 
     def test_analytics_usage_includes_skill_breakdown(self):
         from hermes_state import SessionDB

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1374,19 +1374,48 @@ export interface AnalyticsDailyEntry {
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
+  cache_write_tokens: number;
   reasoning_tokens: number;
-  estimated_cost: number;
-  actual_cost: number;
   sessions: number;
   api_calls: number;
 }
 
 export interface AnalyticsModelEntry {
   model: string;
+  provider: string;
   input_tokens: number;
   output_tokens: number;
-  estimated_cost: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  reasoning_tokens: number;
   sessions: number;
+  api_calls: number;
+}
+
+export interface AnalyticsTotals {
+  total_input: number;
+  total_output: number;
+  total_tokens: number;
+  total_cache_read: number;
+  total_cache_write: number;
+  total_reasoning: number;
+  total_sessions: number;
+  total_api_calls: number;
+  avg_tokens_per_session: number;
+}
+
+export interface AnalyticsTopSessionEntry {
+  session_id: string;
+  title: string | null;
+  model: string | null;
+  provider: string;
+  started_at: number;
+  ended_at: number | null;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  reasoning_tokens: number;
   api_calls: number;
 }
 
@@ -1409,16 +1438,12 @@ export interface AnalyticsSkillsSummary {
 export interface AnalyticsResponse {
   daily: AnalyticsDailyEntry[];
   by_model: AnalyticsModelEntry[];
-  totals: {
-    total_input: number;
-    total_output: number;
-    total_cache_read: number;
-    total_reasoning: number;
-    total_estimated_cost: number;
-    total_actual_cost: number;
-    total_sessions: number;
-    total_api_calls: number;
+  top_sessions: AnalyticsTopSessionEntry[];
+  totals: AnalyticsTotals;
+  comparison: {
+    previous_totals: AnalyticsTotals;
   };
+  period_days: number;
   skills: {
     summary: AnalyticsSkillsSummary;
     top_skills: AnalyticsSkillEntry[];

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -493,7 +493,7 @@ export default function AnalyticsPage() {
                 Token analytics hidden
               </h2>
               <p>
-                The token, cost, and per-day analytics on this page are a
+                The token and per-day analytics on this page are a
                 local debug estimate. They only count successful main-agent
                 responses with a usable <span className="font-mono">usage</span>{" "}
                 block, and silently exclude auxiliary calls (context


### PR DESCRIPTION
## 变更内容

- 扩展 `/api/analytics/usage`，返回新版桌面端需要的 `comparison`、`top_sessions`、`total_tokens`、`avg_tokens_per_session` 等字段。
- 移除费用统计字段，不再返回 `currency`、`estimated_cost`、`actual_cost`、`effective_cost` 等依赖价格表的口径。
- 补充 `cache_write_tokens` 与 `total_cache_write`，支持桌面端计算缓存命中率。
- 将高用量会话按 Token 与 API 调用排序，并提高返回上限，方便前端分页。
- 同步 Web API 类型和 analytics 相关测试。

## 验证

- `/Users/enzo/Documents/GithubProjects/hermes/hermes-agent-cn/.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py -q -k 'analytics_usage'`