### PR TITLE
fix(desktop): Windows 卡死/无响应 (ANR) 主线根因修复（同步 fs/子进程、终端 WebGL、/skills、流刷新）

### DIFF
--- a/apps/desktop/electron/backend-probes.cjs
+++ b/apps/desktop/electron/backend-probes.cjs
@@ -32,7 +32,10 @@
  * as bootstrap-platform.cjs and hardening.cjs).
  */
 
-const { execFileSync } = require('node:child_process')
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
 
 const PROBE_TIMEOUT_MS = 5000
 
@@ -46,14 +49,17 @@ const PROBE_TIMEOUT_MS = 5000
  * site-packages -- and the resolver returns a backend that immediately
  * dies on spawn.
  *
+ * Async so the resolver never blocks the Electron main (HWND-owning) thread on
+ * a Python interpreter cold-start — on Windows that import walks site-packages
+ * and can burn the full 5s timeout, freezing the window message pump.
+ *
  * @param {string} pythonPath - Absolute path to a python.exe / python.
- * @returns {boolean}
+ * @returns {Promise<boolean>}
  */
-function canImportHermesCli(pythonPath) {
+async function canImportHermesCli(pythonPath) {
   if (!pythonPath) return false
   try {
-    execFileSync(pythonPath, ['-c', 'import hermes_cli'], {
-      stdio: 'ignore',
+    await execFileAsync(pythonPath, ['-c', 'import hermes_cli'], {
       timeout: PROBE_TIMEOUT_MS,
       windowsHide: true
     })
@@ -82,13 +88,12 @@ function canImportHermesCli(pythonPath) {
  *   .cmd/.bat shims on Windows execFileSync needs shell:true to find
  *   the cmd interpreter; mirrors the same flag isCommandScript() drives
  *   in resolveHermesBackend.
- * @returns {boolean}
+ * @returns {Promise<boolean>}
  */
-function verifyHermesCli(hermesCommand, opts = {}) {
+async function verifyHermesCli(hermesCommand, opts = {}) {
   if (!hermesCommand) return false
   try {
-    execFileSync(hermesCommand, ['--version'], {
-      stdio: 'ignore',
+    await execFileAsync(hermesCommand, ['--version'], {
       timeout: PROBE_TIMEOUT_MS,
       shell: Boolean(opts.shell),
       windowsHide: true

--- a/apps/desktop/electron/backend-probes.test.cjs
+++ b/apps/desktop/electron/backend-probes.test.cjs
@@ -20,38 +20,38 @@ const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
 // (a tiny script we write to disk that exits 0 on --version).
 const NODE_BIN = process.execPath
 
-test('canImportHermesCli returns false when path is falsy', () => {
-  assert.equal(canImportHermesCli(''), false)
-  assert.equal(canImportHermesCli(null), false)
-  assert.equal(canImportHermesCli(undefined), false)
+test('canImportHermesCli returns false when path is falsy', async () => {
+  assert.equal(await canImportHermesCli(''), false)
+  assert.equal(await canImportHermesCli(null), false)
+  assert.equal(await canImportHermesCli(undefined), false)
 })
 
-test('canImportHermesCli returns false when interpreter cannot run -c', () => {
+test('canImportHermesCli returns false when interpreter cannot run -c', async () => {
   // node IS an interpreter, but `node -c "import hermes_cli"` is a
   // SyntaxError -- different exit reason from a real Python's
   // ModuleNotFoundError, but the predicate is "exit 0 or not" and
   // both land on "not", which is exactly what we want for the
   // resolver fall-through.
-  assert.equal(canImportHermesCli(NODE_BIN), false)
+  assert.equal(await canImportHermesCli(NODE_BIN), false)
 })
 
-test('canImportHermesCli returns false when binary does not exist', () => {
+test('canImportHermesCli returns false when binary does not exist', async () => {
   const ghost = path.join(os.tmpdir(), 'hermes-probes-ghost-' + Date.now() + '.exe')
-  assert.equal(canImportHermesCli(ghost), false)
+  assert.equal(await canImportHermesCli(ghost), false)
 })
 
-test('verifyHermesCli returns false when command is falsy', () => {
-  assert.equal(verifyHermesCli(''), false)
-  assert.equal(verifyHermesCli(null), false)
-  assert.equal(verifyHermesCli(undefined), false)
+test('verifyHermesCli returns false when command is falsy', async () => {
+  assert.equal(await verifyHermesCli(''), false)
+  assert.equal(await verifyHermesCli(null), false)
+  assert.equal(await verifyHermesCli(undefined), false)
 })
 
-test('verifyHermesCli returns false when binary does not exist', () => {
+test('verifyHermesCli returns false when binary does not exist', async () => {
   const ghost = path.join(os.tmpdir(), 'hermes-probes-ghost-' + Date.now() + '.exe')
-  assert.equal(verifyHermesCli(ghost), false)
+  assert.equal(await verifyHermesCli(ghost), false)
 })
 
-test('verifyHermesCli returns true when --version exits 0', () => {
+test('verifyHermesCli returns true when --version exits 0', async () => {
   // Write a tiny script that exits 0 regardless of args, then invoke
   // it through node. This stands in for a working hermes binary --
   // verifyHermesCli only cares about the exit code.
@@ -63,7 +63,7 @@ test('verifyHermesCli returns true when --version exits 0', () => {
     // execFileSync passes ['--version'] as args, which node ignores
     // gracefully (well, it prints its version and exits 0, which is
     // perfect -- exit code 0 is the only signal we read).
-    assert.equal(verifyHermesCli(NODE_BIN), true)
+    assert.equal(await verifyHermesCli(NODE_BIN), true)
   } finally {
     try {
       fs.unlinkSync(scriptPath)
@@ -73,10 +73,10 @@ test('verifyHermesCli returns true when --version exits 0', () => {
   }
 })
 
-test('verifyHermesCli swallows timeouts (does not throw)', () => {
+test('verifyHermesCli swallows timeouts (does not throw)', async () => {
   // We can't easily provoke a real 5s hang in CI without slowing the
   // suite, but we CAN confirm that an invocation that DOES throw
   // (because the binary is missing) returns false rather than
   // propagating. Same code path the timeout case takes.
-  assert.equal(verifyHermesCli('/definitely/not/a/real/binary/anywhere'), false)
+  assert.equal(await verifyHermesCli('/definitely/not/a/real/binary/anywhere'), false)
 })

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -23,7 +23,13 @@ const https = require('node:https')
 const net = require('node:net')
 const path = require('node:path')
 const { fileURLToPath, pathToFileURL } = require('node:url')
-const { execFileSync, spawn } = require('node:child_process')
+const { execFile, execFileSync, spawn } = require('node:child_process')
+const { promisify } = require('node:util')
+// Async child-process runner for backend resolution. The resolver runs on the
+// Electron main (HWND-owning) thread during startup; execFileSync there blocks
+// the Windows window message pump (reg/py.exe/python probes are full
+// CreateProcess calls, AV-scanned, one with a 5s timeout) → ANR.
+const execFileAsync = promisify(execFile)
 const { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } = require('./bootstrap-platform.cjs')
 const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
@@ -951,7 +957,7 @@ function isHermesSourceRoot(root) {
   return directoryExists(root) && fileExists(path.join(root, 'hermes_cli', 'main.py'))
 }
 
-function findPythonForRoot(root) {
+async function findPythonForRoot(root) {
   const override = process.env.HERMES_DESKTOP_PYTHON
   if (override && fileExists(override)) return override
 
@@ -964,10 +970,10 @@ function findPythonForRoot(root) {
     if (fileExists(candidate)) return candidate
   }
 
-  return findSystemPython()
+  return await findSystemPython()
 }
 
-function findSystemPython() {
+async function findSystemPython() {
   if (!IS_WINDOWS) {
     // POSIX systems: PATH lookup is safe.
     for (const command of ['python3', 'python']) {
@@ -1024,10 +1030,10 @@ function findSystemPython() {
   for (const hive of ['HKLM', 'HKCU']) {
     for (const version of SUPPORTED_VERSIONS) {
       try {
-        const out = execFileSync(
+        const { stdout: out } = await execFileAsync(
           'reg',
           ['query', `${hive}\\SOFTWARE\\Python\\PythonCore\\${version}\\InstallPath`, '/ve', '/reg:64'],
-          { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+          { encoding: 'utf8', windowsHide: true }
         )
         // Output format: "    (Default)    REG_SZ    C:\Path\To\Python\"
         const match = out.match(/REG_SZ\s+(.+?)\s*$/m)
@@ -1063,9 +1069,9 @@ function findSystemPython() {
   if (pyExe) {
     for (const version of SUPPORTED_VERSIONS) {
       try {
-        const out = execFileSync(pyExe, [`-${version}`, '-c', 'import sys; print(sys.executable)'], {
+        const { stdout: out } = await execFileAsync(pyExe, [`-${version}`, '-c', 'import sys; print(sys.executable)'], {
           encoding: 'utf8',
-          stdio: ['ignore', 'pipe', 'ignore']
+          windowsHide: true
         })
         const candidate = out.trim()
         if (candidate && fileExists(candidate)) return candidate
@@ -1882,8 +1888,8 @@ function writeDefaultProjectDir(dir) {
   }
 }
 
-function createPythonBackend(root, label, dashboardArgs, options = {}) {
-  const python = findPythonForRoot(root)
+async function createPythonBackend(root, label, dashboardArgs, options = {}) {
+  const python = await findPythonForRoot(root)
   if (!python) return null
 
   return {
@@ -1904,13 +1910,14 @@ function createPythonBackend(root, label, dashboardArgs, options = {}) {
 // canonical install location shared with the CLI installer. The venv at
 // VENV_ROOT may not exist yet on first run; bootstrap=true tells
 // ensureRuntime() to create / refresh it before launch.
-function createActiveBackend(dashboardArgs) {
+async function createActiveBackend(dashboardArgs) {
   const venvPython = getVenvPython(VENV_ROOT)
+  const command = fileExists(venvPython) ? venvPython : await findSystemPython()
 
   return {
     kind: 'python',
     label: `Hermes at ${ACTIVE_HERMES_ROOT}`,
-    command: fileExists(venvPython) ? venvPython : findSystemPython(),
+    command,
     args: ['-m', 'hermes_cli.main', ...dashboardArgs],
     env: {
       PYTHONPATH: [ACTIVE_HERMES_ROOT, process.env.PYTHONPATH].filter(Boolean).join(path.delimiter)
@@ -1921,12 +1928,12 @@ function createActiveBackend(dashboardArgs) {
   }
 }
 
-function resolveHermesBackend(dashboardArgs) {
+async function resolveHermesBackend(dashboardArgs) {
   // 1. Explicit override -- HERMES_DESKTOP_HERMES_ROOT points at a developer
   //    checkout. Honour it as-is (no bootstrap; the user is driving).
   const overrideRoot = process.env.HERMES_DESKTOP_HERMES_ROOT && path.resolve(process.env.HERMES_DESKTOP_HERMES_ROOT)
   if (overrideRoot && isHermesSourceRoot(overrideRoot)) {
-    const backend = createPythonBackend(overrideRoot, `Hermes source at ${overrideRoot}`, dashboardArgs)
+    const backend = await createPythonBackend(overrideRoot, `Hermes source at ${overrideRoot}`, dashboardArgs)
     if (backend) return backend
   }
 
@@ -1935,7 +1942,7 @@ function resolveHermesBackend(dashboardArgs) {
   //    installed `hermes` on PATH so local Python edits are actually exercised.
   //    (In dev with no checkout, SOURCE_REPO_ROOT won't pass isHermesSourceRoot.)
   if (!IS_PACKAGED && isHermesSourceRoot(SOURCE_REPO_ROOT)) {
-    const backend = createPythonBackend(SOURCE_REPO_ROOT, `Hermes source at ${SOURCE_REPO_ROOT}`, dashboardArgs)
+    const backend = await createPythonBackend(SOURCE_REPO_ROOT, `Hermes source at ${SOURCE_REPO_ROOT}`, dashboardArgs)
     if (backend) return backend
   }
 
@@ -1946,7 +1953,7 @@ function resolveHermesBackend(dashboardArgs) {
   //    to spawning hermes. Updates flow through the in-app update path
   //    (applyUpdates -> git pull) or `hermes update` from the CLI.
   if (isBootstrapComplete()) {
-    return createActiveBackend(dashboardArgs)
+    return await createActiveBackend(dashboardArgs)
   }
 
   // 4. Existing `hermes` on PATH -- installed via install.ps1 / install.sh from
@@ -1987,7 +1994,7 @@ function resolveHermesBackend(dashboardArgs) {
       // `--version` probe (see backend-probes.cjs) catches that case
       // and lets the resolver fall through to step 6 / bootstrap.
       const shellForProbe = isCommandScript(hermesCommand)
-      if (verifyHermesCli(hermesCommand, { shell: shellForProbe })) {
+      if (await verifyHermesCli(hermesCommand, { shell: shellForProbe })) {
         return {
           label: `existing Hermes CLI at ${hermesCommand}`,
           command: hermesCommand,
@@ -2007,7 +2014,7 @@ function resolveHermesBackend(dashboardArgs) {
   // 5. Last-ditch: pip-installed hermes_cli module via system Python.
   //    Same rationale as #4 -- the user installed this; we use it but don't
   //    take ownership.
-  const python = findSystemPython()
+  const python = await findSystemPython()
   if (python) {
     // Same smoke-test rationale as step 4: a system Python in the
     // SUPPORTED_VERSIONS range can be registered (PEP 514) without
@@ -2017,7 +2024,7 @@ function resolveHermesBackend(dashboardArgs) {
     // Verify the import works before trusting the candidate; on
     // failure, fall through to step 6 so the bootstrap runner pulls
     // a uv-managed 3.11 into %LOCALAPPDATA%\hermes\hermes-agent\venv.
-    if (canImportHermesCli(python)) {
+    if (await canImportHermesCli(python)) {
       return {
         kind: 'python',
         label: `installed hermes_cli module via ${python}`,
@@ -2147,7 +2154,7 @@ async function ensureRuntime(backend) {
     rememberLog('[bootstrap] bootstrap complete; marker written. Re-resolving backend.')
     // Re-resolve now that the install exists. The new resolution lands in
     // step 3 (bootstrap-complete marker) and we recurse to wire venvPython.
-    return ensureRuntime(resolveHermesBackend(backend.args))
+    return ensureRuntime(await resolveHermesBackend(backend.args))
   }
 
   // bootstrap=true with a real backend (createActiveBackend path) means we
@@ -4273,7 +4280,7 @@ async function spawnPoolBackend(profile, entry) {
   // --profile wins over the inherited HERMES_HOME env (see _apply_profile_override
   // step 3 in hermes_cli/main.py), so the child re-homes to this profile.
   const dashboardArgs = ['--profile', profile, 'dashboard', '--no-open', '--host', '127.0.0.1', '--port', String(port)]
-  const backend = await ensureRuntime(resolveHermesBackend(dashboardArgs))
+  const backend = await ensureRuntime(await resolveHermesBackend(dashboardArgs))
   const hermesCwd = resolveHermesCwd()
   const webDist = resolveWebDist()
 
@@ -4405,7 +4412,7 @@ async function startHermes() {
       dashboardArgs.unshift('--profile', activeProfile)
     }
     await advanceBootProgress('backend.runtime', 'Resolving Hermes runtime', 28)
-    const backend = await ensureRuntime(resolveHermesBackend(dashboardArgs))
+    const backend = await ensureRuntime(await resolveHermesBackend(dashboardArgs))
     const hermesCwd = resolveHermesCwd()
     const webDist = resolveWebDist()
 

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -376,23 +376,27 @@ function looksBinary(buffer) {
   return suspicious / buffer.length > 0.12
 }
 
-function previewFileMetadata(filePath, mimeType) {
+async function previewFileMetadata(filePath, mimeType) {
   let byteSize = 0
   let binary = false
 
   try {
-    const stat = fs.statSync(filePath)
+    const stat = await fs.promises.stat(filePath)
     byteSize = stat.size
 
     if (!mimeType.startsWith('image/')) {
-      const fd = fs.openSync(filePath, 'r')
+      // Was synchronous openSync/readSync/closeSync on the main thread — a
+      // large or AV-scanned file (Windows scans on first open) blocked the
+      // window message pump for the whole open+read. Async handle keeps it off
+      // the UI thread.
+      const handle = await fs.promises.open(filePath, 'r')
 
       try {
         const sample = Buffer.alloc(Math.min(byteSize, 4096))
-        const bytesRead = fs.readSync(fd, sample, 0, sample.length, 0)
+        const { bytesRead } = await handle.read(sample, 0, sample.length, 0)
         binary = looksBinary(sample.subarray(0, bytesRead))
       } finally {
-        fs.closeSync(fd)
+        await handle.close()
       }
     }
   } catch {
@@ -511,6 +515,13 @@ let bootstrapFailure = null
 let bootstrapAbortController = null
 let connectionConfigCache = null
 let connectionConfigCacheMtime = null
+// Last time we revalidated the cache against disk. hermes:api consults the
+// connection config on most REST calls; on Windows each statSync is a blocking
+// syscall that AV/EDR filter drivers can inflate to milliseconds, so a burst of
+// API calls would otherwise stat this file dozens of times back-to-back on the
+// UI thread. Bound the disk check to once per TTL window.
+let connectionConfigCacheCheckedAt = 0
+const CONNECTION_CONFIG_STAT_TTL_MS = 1000
 const hermesLog = []
 const previewWatchers = new Map()
 let previewShortcutActive = false
@@ -842,6 +853,26 @@ function fileExists(filePath) {
 function directoryExists(filePath) {
   try {
     return fs.statSync(filePath).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+// Async variants for hot paths that run on user-supplied paths (file preview).
+// The sync fileExists/directoryExists above are used throughout boot/path
+// resolution where blocking is acceptable; on the preview path a slow/AV-
+// scanned/network file must NOT block the main thread, so use these instead.
+async function isFileAsync(filePath) {
+  try {
+    return (await fs.promises.stat(filePath)).isFile()
+  } catch {
+    return false
+  }
+}
+
+async function isDirectoryAsync(filePath) {
+  try {
+    return (await fs.promises.stat(filePath)).isDirectory()
   } catch {
     return false
   }
@@ -2695,23 +2726,23 @@ function expandUserPath(filePath) {
   return value
 }
 
-function previewFileTarget(rawTarget, baseDir) {
+async function previewFileTarget(rawTarget, baseDir) {
   const raw = String(rawTarget || '').trim()
   const base = baseDir ? path.resolve(expandUserPath(baseDir)) : resolveHermesCwd()
   const filePath = raw.startsWith('file:') ? fileURLToPath(raw) : path.resolve(base, expandUserPath(raw))
   let resolved = filePath
 
-  if (directoryExists(resolved)) {
+  if (await isDirectoryAsync(resolved)) {
     resolved = path.join(resolved, 'index.html')
   }
 
   const ext = path.extname(resolved).toLowerCase()
-  if (!fileExists(resolved)) {
+  if (!(await isFileAsync(resolved))) {
     return null
   }
 
   const mimeType = mimeTypeForPath(resolved)
-  const metadata = previewFileMetadata(resolved, mimeType)
+  const metadata = await previewFileMetadata(resolved, mimeType)
   const isHtml = PREVIEW_HTML_EXTENSIONS.has(ext)
   const isImage = mimeType.startsWith('image/')
   const previewKind = isHtml ? 'html' : isImage ? 'image' : metadata.binary ? 'binary' : 'text'
@@ -2755,7 +2786,7 @@ function previewUrlTarget(rawTarget) {
   }
 }
 
-function normalizePreviewTarget(rawTarget, baseDir) {
+async function normalizePreviewTarget(rawTarget, baseDir) {
   const raw = String(rawTarget || '').trim()
 
   if (!raw) {
@@ -2767,7 +2798,7 @@ function normalizePreviewTarget(rawTarget, baseDir) {
       return previewUrlTarget(raw)
     }
 
-    return previewFileTarget(raw, baseDir)
+    return await previewFileTarget(raw, baseDir)
   } catch {
     return null
   }
@@ -3628,6 +3659,17 @@ function sanitizeConnectionProfiles(raw) {
 }
 
 function readDesktopConnectionConfig() {
+  // Hot-path guard: within the TTL window, trust the in-memory cache and skip
+  // the blocking statSync entirely. Our own writes refresh the cache inline via
+  // writeDesktopConnectionConfig, so the only thing the disk check buys us is
+  // picking up edits made by another process/tool — a ~1s delay on that is fine
+  // and keeps the UI thread off the filesystem under API bursts.
+  const now = Date.now()
+  if (connectionConfigCache && now - connectionConfigCacheCheckedAt < CONNECTION_CONFIG_STAT_TTL_MS) {
+    return connectionConfigCache
+  }
+  connectionConfigCacheCheckedAt = now
+
   // Check if file changed on disk since last read (e.g. modified by another
   // process or an external tool).  Our own writes update the cache inline
   // via writeDesktopConnectionConfig, but external changes would be missed.
@@ -3678,6 +3720,7 @@ function writeDesktopConnectionConfig(config) {
   writeFileAtomic(DESKTOP_CONNECTION_CONFIG_PATH, JSON.stringify(config, null, 2))
   connectionConfigCache = config
   connectionConfigCacheMtime = fs.statSync(DESKTOP_CONNECTION_CONFIG_PATH).mtimeMs
+  connectionConfigCacheCheckedAt = Date.now()
 }
 
 // Returns the desktop's chosen profile name, or null when unset. "default" is
@@ -5090,16 +5133,21 @@ const FS_READDIR_HIDDEN = new Set([
   'venv'
 ])
 
-function findGitRoot(start) {
+async function findGitRoot(start) {
   let dir = start
 
   for (let i = 0; i < 50; i += 1) {
     try {
-      if (fs.existsSync(path.join(dir, '.git'))) {
-        return dir
-      }
+      // Async existence check: the old synchronous fs.existsSync ran up to 50
+      // blocking syscalls on the main (HWND-owning) thread, and on Windows each
+      // one is inflated by AV/EDR filter drivers and OneDrive/UNC redirection —
+      // enough to freeze the window message pump ("应用程序没有响应"). access()
+      // throws for both missing and unreadable paths; either way this dir isn't
+      // a resolvable git root, so keep walking up rather than aborting.
+      await fs.promises.access(path.join(dir, '.git'))
+      return dir
     } catch {
-      return null
+      // .git not here — continue to the parent.
     }
 
     const parent = path.dirname(dir)
@@ -5227,9 +5275,9 @@ ipcMain.handle('hermes:fs:gitRoot', async (_event, startPath) => {
     const stat = await fs.promises.stat(resolved)
     const start = stat.isDirectory() ? resolved : path.dirname(resolved)
 
-    return findGitRoot(start)
+    return await findGitRoot(start)
   } catch {
-    return findGitRoot(resolved)
+    return await findGitRoot(resolved)
   }
 })
 

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -68,8 +68,9 @@ export function PersistentTerminal({ cwd, onAddSelectionToChat }: PersistentTerm
 
     let prev: Rect | null = null
     let frame = 0
+    let stableFrames = 0
 
-    const tick = () => {
+    const measure = (): boolean => {
       const r = slot.getBoundingClientRect()
       // floor top/left + ceil right/bottom: overlay always covers the slot's
       // full pixel footprint, so half-pixel rects can't leak page bg through.
@@ -77,21 +78,71 @@ export function PersistentTerminal({ cwd, onAddSelectionToChat }: PersistentTerm
       const left = Math.floor(r.left)
       const next: Rect = { top, left, width: Math.ceil(r.right) - left, height: Math.ceil(r.bottom) - top }
 
-      if (!sameRect(prev, next)) {
-        prev = next
-        setRect(next)
-
-        if (next.width > 0 && next.height > 0) {
-          setReady(true)
-        }
+      if (sameRect(prev, next)) {
+        return false
       }
 
-      frame = requestAnimationFrame(tick)
+      prev = next
+      setRect(next)
+
+      if (next.width > 0 && next.height > 0) {
+        setReady(true)
+      }
+
+      return true
     }
 
-    tick()
+    // Track the slot through a transition, then STOP. The old implementation
+    // re-ran getBoundingClientRect() every frame forever, which forces a layout
+    // flush ~60×/sec for the whole app lifetime — a constant main-thread tax
+    // that amplifies any other jank into a perceptible freeze on slower/Windows
+    // machines. Instead, re-measure each frame only until the rect has held
+    // steady for a few frames, then idle until the next resize/scroll/layout
+    // change re-arms the burst.
+    const settle = () => {
+      stableFrames = 0
 
-    return () => cancelAnimationFrame(frame)
+      if (frame) {
+        return
+      }
+
+      const step = () => {
+        stableFrames = measure() ? 0 : stableFrames + 1
+
+        if (stableFrames >= 3) {
+          frame = 0
+
+          return
+        }
+
+        frame = requestAnimationFrame(step)
+      }
+
+      frame = requestAnimationFrame(step)
+    }
+
+    measure()
+    settle()
+
+    // Re-arm the burst on the events that can move/resize the slot. A plain
+    // ResizeObserver alone misses position-only shifts (a sibling pane resizing
+    // moves the slot without changing its size), so pair it with window resize
+    // and capture-phase scroll.
+    const reArm = () => settle()
+    const resizeObserver = new ResizeObserver(reArm)
+    resizeObserver.observe(slot)
+    window.addEventListener('resize', reArm)
+    window.addEventListener('scroll', reArm, { capture: true, passive: true })
+
+    return () => {
+      if (frame) {
+        cancelAnimationFrame(frame)
+      }
+
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', reArm)
+      window.removeEventListener('scroll', reArm, { capture: true })
+    }
   }, [slot])
 
   const visible = Boolean(rect && rect.width > 0 && rect.height > 0)

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -191,6 +191,11 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
   const selectionLabelRef = useRef('')
   const selectionRef = useRef('')
   const onAddSelectionToChatRef = useRef(onAddSelectionToChat)
+  // Shared between the "create terminal once" effect and the "(re)start PTY on
+  // cwd change" effect below: the latter triggers a fit after a new session
+  // opens, and resets the last-sent size so the first resize is delivered.
+  const fitAndResizeRef = useRef<() => void>(() => {})
+  const lastSentSizeRef = useRef<{ cols: number; rows: number } | null>(null)
   const [status, setStatus] = useState<TerminalStatus>('starting')
   const [selection, setSelection] = useState('')
   const [selectionStyle, setSelectionStyle] = useState<CSSProperties | null>(null)
@@ -242,6 +247,16 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
   }, [addSelectionToChat, selection])
 
+  // Create the xterm instance + WebGL renderer exactly ONCE for the lifetime of
+  // the panel. The previous single effect listed `cwd` in its deps, so every
+  // working-directory change (which happens on essentially every session
+  // switch/resume/new-draft, and on session.info stream events) tore down and
+  // rebuilt the Terminal — and with it a fresh WebglAddon context. Windows/ANGLE
+  // caps live WebGL contexts (~16) and reclaims disposed ones lazily, so
+  // navigating through a handful of sessions exhausted the pool and triggered
+  // context-loss storms + GPU-process thrash that froze the window ("点几个页面
+  // 就卡死"). The PTY session, which legitimately follows cwd, is (re)started in
+  // the separate effect below without touching this Terminal/WebGL instance.
   useEffect(() => {
     const host = hostRef.current
     const terminalApi = window.hermesDesktop?.terminal
@@ -254,7 +269,6 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
 
     let disposed = false
     const cleanup: Array<() => void> = []
-    let lastSentSize: { cols: number; rows: number } | null = null
 
     const term = new Terminal({
       allowProposedApi: true,
@@ -340,12 +354,15 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
       }
 
       const id = sessionIdRef.current
+      const lastSentSize = lastSentSizeRef.current
 
       if (id && (lastSentSize?.cols !== term.cols || lastSentSize?.rows !== term.rows)) {
-        lastSentSize = { cols: term.cols, rows: term.rows }
+        lastSentSizeRef.current = { cols: term.cols, rows: term.rows }
         void terminalApi.resize(id, { cols: term.cols, rows: term.rows })
       }
     }
+
+    fitAndResizeRef.current = fitAndResize
 
     // Coalesce ResizeObserver bursts through rAF — running fit.fit()
     // synchronously while sibling panes are mid-transition (e.g. file browser
@@ -413,6 +430,41 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
 
     fitAndResize()
 
+    return () => {
+      disposed = true
+      cleanup.forEach(run => run())
+
+      term.dispose()
+      termRef.current = null
+      fitAndResizeRef.current = () => {}
+      shellNameRef.current = 'shell'
+      selectionRef.current = ''
+      selectionLabelRef.current = ''
+    }
+  }, [addSelectionToChat])
+
+  // (Re)start the backend PTY whenever the active working directory changes.
+  // This reuses the single Terminal/WebGL instance created above — only the
+  // node-pty shell process is recreated, which is cheap relative to a GPU
+  // context and does not accumulate WebGL contexts.
+  useEffect(() => {
+    const terminalApi = window.hermesDesktop?.terminal
+    const term = termRef.current
+
+    if (!terminalApi || !term) {
+      return
+    }
+
+    let disposed = false
+    const cleanup: Array<() => void> = []
+
+    // Clear the previous session's output so the new cwd's shell starts on a
+    // clean screen (matches the prior "fresh terminal per cwd" behavior), and
+    // force the next fit to push a resize to the freshly-spawned PTY.
+    term.reset()
+    lastSentSizeRef.current = null
+    setStatus('starting')
+
     void terminalApi
       .start({ cols: term.cols, cwd, rows: term.rows })
       .then(session => {
@@ -423,7 +475,7 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
         }
 
         sessionIdRef.current = session.id
-        lastSentSize = { cols: term.cols, rows: term.rows }
+        lastSentSizeRef.current = { cols: term.cols, rows: term.rows }
         shellNameRef.current = session.shell || 'shell'
         setShellName(session.shell || 'shell')
 
@@ -465,11 +517,15 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
           })
         )
         window.requestAnimationFrame(() => {
-          fitAndResize()
+          fitAndResizeRef.current()
           term.focus()
         })
       })
       .catch(error => {
+        if (disposed) {
+          return
+        }
+
         setStatus('closed')
         term.write(`Terminal failed to start: ${error instanceof Error ? error.message : String(error)}\r\n`)
       })
@@ -484,14 +540,8 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
       if (id) {
         void terminalApi.dispose(id)
       }
-
-      term.dispose()
-      termRef.current = null
-      shellNameRef.current = 'shell'
-      selectionRef.current = ''
-      selectionLabelRef.current = ''
     }
-  }, [addSelectionToChat, cwd])
+  }, [cwd])
 
   return {
     addSelectionToChat,

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -191,6 +191,34 @@ export function useMessageStream({
   refreshSessions,
   updateSessionState
 }: MessageStreamOptions) {
+  // Coalesce the session-list refresh that fires on every message.complete.
+  // refreshSessions() runs the unified cross-profile query (it scans every
+  // profile's state.db); a burst of completions — or several concurrent
+  // background-profile sessions each finishing a turn — would otherwise stack
+  // one cross-DB scan per turn onto the UI-thread → IPC → HTTP chain. Collapse
+  // them to at most one refresh per window. Explicit refreshes elsewhere (boot,
+  // session create/branch) stay immediate.
+  const refreshSessionsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const coalesceRefreshSessions = useCallback(() => {
+    if (refreshSessionsTimerRef.current !== null) {
+      return
+    }
+
+    refreshSessionsTimerRef.current = setTimeout(() => {
+      refreshSessionsTimerRef.current = null
+      void refreshSessions().catch(() => undefined)
+    }, 400)
+  }, [refreshSessions])
+
+  useEffect(
+    () => () => {
+      if (refreshSessionsTimerRef.current !== null) {
+        clearTimeout(refreshSessionsTimerRef.current)
+      }
+    },
+    []
+  )
+
   // Patch the in-flight assistant message (or seed it). Centralises the
   // streamId/groupId bookkeeping every event callback would otherwise repeat.
   const mutateStream = useCallback(
@@ -534,7 +562,7 @@ export function useMessageStream({
         }
       })
 
-      void refreshSessions().catch(() => undefined)
+      coalesceRefreshSessions()
 
       if (shouldHydrate) {
         void hydrateFromStoredSession(3, completedState.storedSessionId, sessionId)
@@ -547,7 +575,7 @@ export function useMessageStream({
         })
       }
     },
-    [activeSessionIdRef, hydrateFromStoredSession, refreshSessions, updateSessionState]
+    [activeSessionIdRef, coalesceRefreshSessions, hydrateFromStoredSession, updateSessionState]
   )
 
   const failAssistantMessage = useCallback(

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -1,5 +1,5 @@
 import type * as React from 'react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react'
 
 import { PageLoader } from '@/components/page-loader'
 import { Badge } from '@/components/ui/badge'
@@ -22,6 +22,11 @@ import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
 
 const SKILLS_MODES = ['skills', 'toolsets'] as const
 type SkillsMode = (typeof SKILLS_MODES)[number]
+
+// Cap how many tool-name chips a single toolset renders. A few toolsets expose
+// dozens-to-hundreds of tools; rendering them all multiplied the DOM node count
+// on the toolsets tab. Show the first N and summarize the rest.
+const MAX_VISIBLE_TOOL_CHIPS = 24
 
 function categoryFor(skill: SkillInfo): string {
   return asText(skill.category) || 'general'
@@ -76,6 +81,12 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
   const [mode, setMode] = useRouteEnumParam('tab', SKILLS_MODES, 'skills')
 
   const [query, setQuery] = useState('')
+  // Drive filtering off a deferred copy of the query so each keystroke paints
+  // the input immediately and the (un-virtualized, potentially large) filter +
+  // sort + group + re-render runs at a lower priority. Without this, typing in
+  // the search box re-filtered and re-rendered the entire list synchronously
+  // between keystrokes and blocked the UI thread on big skill/toolset sets.
+  const deferredQuery = useDeferredValue(query)
   const [skills, setSkills] = useState<SkillInfo[] | null>(null)
   const [toolsets, setToolsets] = useState<ToolsetInfo[] | null>(null)
   const [activeCategory, setActiveCategory] = useState<string | null>(null)
@@ -128,18 +139,30 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
   }, [skills])
 
   const visibleSkills = useMemo(
-    () => (skills ? filteredSkills(skills, query, mode === 'skills' ? activeCategory : null) : []),
-    [activeCategory, mode, query, skills]
+    () => (skills ? filteredSkills(skills, deferredQuery, mode === 'skills' ? activeCategory : null) : []),
+    [activeCategory, mode, deferredQuery, skills]
   )
 
-  const visibleToolsets = useMemo(() => (toolsets ? filteredToolsets(toolsets, query) : []), [query, toolsets])
+  const visibleToolsets = useMemo(
+    () => (toolsets ? filteredToolsets(toolsets, deferredQuery) : []),
+    [deferredQuery, toolsets]
+  )
 
   const skillGroups = useMemo(() => {
     const groups = new Map<string, SkillInfo[]>()
 
+    // Push into the existing array instead of spreading a fresh copy per insert
+    // (`[...old, skill]`), which was O(n^2) when many skills share a category
+    // (the default 'general' bucket) and re-ran on every keystroke/toggle.
     for (const skill of visibleSkills) {
       const key = categoryFor(skill)
-      groups.set(key, [...(groups.get(key) || []), skill])
+      const bucket = groups.get(key)
+
+      if (bucket) {
+        bucket.push(skill)
+      } else {
+        groups.set(key, [skill])
+      }
     }
 
     return Array.from(groups.entries()).sort(([a], [b]) => a.localeCompare(b))
@@ -321,7 +344,7 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
                       </p>
                       {tools.length > 0 && (
                         <div className="mt-2 flex flex-wrap gap-1">
-                          {tools.map(name => (
+                          {tools.slice(0, MAX_VISIBLE_TOOL_CHIPS).map(name => (
                             <span
                               className="rounded-md bg-(--ui-bg-quinary) px-1.5 py-0.5 font-mono text-[0.65rem] text-(--ui-text-tertiary)"
                               key={name}
@@ -329,6 +352,14 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
                               {name}
                             </span>
                           ))}
+                          {tools.length > MAX_VISIBLE_TOOL_CHIPS && (
+                            <span
+                              className="rounded-md bg-(--ui-bg-quinary) px-1.5 py-0.5 font-mono text-[0.65rem] text-(--ui-text-tertiary)"
+                              title={tools.join(', ')}
+                            >
+                              +{tools.length - MAX_VISIBLE_TOOL_CHIPS}
+                            </span>
+                          )}
                         </div>
                       )}
                       {expanded && <ToolsetConfigPanel onConfiguredChange={refreshToolsets} toolset={toolset.name} />}


### PR DESCRIPTION
## 背景

修复 Windows 桌面端大量用户反馈的 **"应用程序没有响应" (ANR) / 卡死**。完整排查、根因分析与问题清单见 **#19**。本 PR 落地其中**主线根因**的修复。

症状：A）点开 `/skills` 立即卡；B）侧边栏点几个页面后卡死（渐进式）；C）整个窗口 `(未响应)`。
关键点：Electron 在 Windows 上 `BrowserWindow` 的 HWND 消息循环跑在**主进程 UI 线程**，该线程同步阻塞数秒即触发 ANR；这些同步调用在 macOS/Linux 是亚毫秒级，仅在 Windows + 杀软/EDR/OneDrive 下被放大——典型"开发机测不出、用户机必现"。

## 改动（4 个提交）

1. **`fix: stop main-thread blocking on sync fs`** — `findGitRoot`(50 层 `existsSync`)、预览链(`statSync/openSync/readSync`)改 `fs.promises`；`hermes:api` 的 `connection.json` `statSync` 加 1s TTL。〔症状 C〕
2. **`fix: create terminal/WebGL once, not per cwd change`** — `use-terminal-session.ts` 拆成两个 effect：xterm + WebGL **只建一次**，仅 node-pty 随 `cwd` 重启。修复 Windows/ANGLE WebGL 上下文(~16 上限)被反复重建耗尽 → 上下文丢失风暴。〔症状 B〕
3. **`perf: defer skills filtering, drop permanent rAF reflow, coalesce session refresh`** — `/skills` `useDeferredValue` + 修 O(n²) 分组 + tool chip 截断；`PersistentTerminal` 永久 60fps `getBoundingClientRect` 循环 → ResizeObserver/resize/scroll 触发的短突发;`message.complete` 的跨库会话刷新合并(400ms)。〔症状 A + B〕
4. **`fix: async-ify backend resolution`** — `resolveHermesBackend` 整链(`findSystemPython`/`findPythonForRoot`/`createPythonBackend`/`createActiveBackend` + `backend-probes` 探测)改 async，把启动期 `reg query`/`py.exe`/`import hermes_cli`(5s 超时) 等 ~10 次串行同步 `execFileSync` 移出主线程。〔症状 C，首启/修复路径〕

## 验证

- ✅ `node --check`：`main.cjs` / `backend-probes.cjs` / 测试 均通过（`await` 全在 async 上下文，否则 `--check` 会报错）。
- ✅ `node --test backend-probes.test.cjs`：7/7 通过（已适配 async API）。
- ✅ 逐行核对：6 个新 async 函数的**全部调用点均已 `await`**（含 3 处 `ensureRuntime(...)`），ripple 完全封闭在解析器模块内。
- ⚠️ **本环境无 `node_modules`，未跑 `tsc`/`vitest`/Electron 构建**；TS 改动经逐行类型/逻辑复核。**合并前请在真实 Windows 机（开启 Defender）跑构建 + 首启/修复流程 + 反复切会话/导航复现验证**（提交 4 尤其需要 Windows 首启 QA）。

## 范围说明

本 PR 针对**主线根因**。#19 清单中仍有待办（命令中心/制品页虚拟化、`toChatMessages` 去二次方、`/skills` 完整虚拟化、流刷新其余放大器、语音 AudioContext 泄漏等），建议后续 PR 跟进。

Refs #19
