### PR TITLE
feat(windows): PowerShell (pwsh) 原生执行 + 终端描述运行时自适应（@MaxwellGeng）

### DIFF
--- a/FORK_NOTES.md
+++ b/FORK_NOTES.md
@@ -20,6 +20,7 @@ This document explains the fork-specific changes on `main` that diverge from ups
 | **P-013** | `model_tools.py`, `tests/run_agent/test_repair_tool_arg_keys.py` | Adds automatic tool argument key repair (`repair_tool_arg_keys`) with alias tables, per-tool overrides, fuzzy fallback, nested object/array recursion, and an optional callback hook; integrated into `handle_function_call` before type coercion | LLMs often misname arguments (e.g. "file"→"path", "cmd"→"command"); this makes tool dispatch resilient to common drift without weakening JSON Schemas | Should be upstreamed |
 | **P-014** | `.github/workflows/release-runtime.yml`, `tools/mcp_tool.py`, `hermes_cli/config.py`, `docs/RUNTIME_RELEASES.md`, `tests/tools/test_mcp_tool.py` | Bundles the native MCP client SDK into the frozen runtime (install entry later folded into the `cn-desktop` extra — see P-015 — plus `--collect-submodules/--copy-metadata mcp` and a CI assert on `mcp-*.dist-info`), and makes `discover_mcp_tools()` warn once when `mcp_servers` is configured but the SDK is absent instead of silently no-op'ing at debug | Issue #16: the desktop runtime shipped without the `mcp` extra, so `_MCP_AVAILABLE=False` and configured `mcp_servers` registered no tools with no INFO-level log. The packaging fix is fork-specific; the diagnostic + known-root-key are generic | Packaging change is CN-specific; the `mcp_tool.py` warning and `mcp_servers` known-root-key should be upstreamed |
 | **P-015** | `pyproject.toml`, `.github/workflows/release-runtime.yml`, `docs/RUNTIME_RELEASES.md`, `uv.lock` | Adds a `cn-desktop` aggregate extra that pre-bakes every backend the frozen runtime exposes (`web`, `anthropic`, `mcp`, `feishu`, `dingtalk`, `wecom`, plus 微信's `aiohttp`/`qrcode`/`cryptography`). The release workflow installs `.[cn-desktop]`, collects the IM SDK submodules + metadata, runs a build-env import smoke test, and asserts each backend's `dist-info` in the frozen output | Desktop report: the 飞书/钉钉/企微/微信 adapters silently degraded to "unavailable" because their SDKs (`lark-oapi`, `dingtalk-stream`, …) were never bundled and the frozen build can't lazy-install. Same root cause as P-014, generalized to all desktop backends | Packaging is CN-specific; not upstreamed (upstream doesn't build these artifacts) |
+| **P-016** | `tools/terminal_tool.py`, `tools/environments/local.py`, `model_tools.py`, `tests/tools/test_terminal_dynamic_description.py` | PowerShell (pwsh) native execution: on Windows, detects pwsh and uses it as the primary local shell with full lifecycle support (spawn, wrap, init_session, cwd tracking); adds runtime-adaptive terminal tool description that replaces Linux/bash command references with pwsh cmdlets when the active shell is pwsh; adds shell-fingerprint to tool-definitions cache key so mid-session pwsh auto-install invalidates the description | Agent on Windows was hardcoded to Git Bash; pwsh is faster (-NoProfile), has better Windows-native path handling, and avoids the POSIX-translation overhead. The static `TERMINAL_TOOL_DESCRIPTION` contained Linux-only command references (`cat/head/tail`, `grep/rg/find`, `echo/cat heredoc`) that are misleading under pwsh | Should be upstreamed |
 
 > **P-001** (provider dict-vs-list mismatch in `tui_gateway/server.py`) — **dropped from this fork**. Upstream has since fixed it; the line `user_provs = cfg.get("providers")` in `_apply_model_switch` already does the right thing.
 
@@ -287,6 +288,48 @@ opening an upstream PR.
 **Side effects**: The frozen runtime grows by the IM SDKs and their transitive deps (notably the pure-Python `alibabacloud_*` chain). All are pure-Python with cross-platform wheels/sdists — unlike `matrix`'s `python-olm`, which needs a C toolchain and is intentionally still excluded. No change to source installs.
 
 **Should we upstream?** No — upstream doesn't build these PyInstaller artifacts. The `cn-desktop` extra and packaging are CN-runtime-specific.
+### P-016: PowerShell (pwsh) native execution + runtime-adaptive terminal description
+
+**Symptom**: On Windows, the agent was hardcoded to always use Git Bash. PowerShell 7 (pwsh) is faster to start (`-NoProfile`), handles Windows paths natively (no `/c/foo` translation), and is the default shell on modern Windows. Additionally, the terminal tool's static `TERMINAL_TOOL_DESCRIPTION` referenced Linux/bash commands (`cat/head/tail`, `grep/rg/find`, `echo/cat heredoc`, `Pipe git output to cat`) that don't exist on native pwsh — the LLM would either try them and fail, or not know the pwsh equivalents to avoid.
+
+**Root cause**: Upstream's `LocalEnvironment` is bash-only. The terminal tool description is a hardcoded static string assuming a Linux environment.
+
+**What the patch does**:
+
+1. **`tools/environments/local.py`** — Shell resolution and pwsh execution:
+   - Adds `_resolve_shell()`: detects pwsh vs bash on Windows. Respects `HERMES_SHELL_TYPE` (auto/pwsh/bash) and `HERMES_PWSH_PATH` env overrides. Falls back to Git Bash when pwsh is unavailable. Uses the existing `_find_pwsh` (with auto-install) from `tools/environments/_find_pwsh.py`.
+   - `LocalEnvironment.__init__` calls `_resolve_shell()` and stores `self._shell_type` / `self._shell_path`.
+   - Adds `_run_pwsh()`: spawns pwsh with `-NoProfile -Command <script>`, handles stdin piping, Windows creation flags.
+   - Adds `_wrap_command_pwsh()`: builds a PowerShell script that executes `Set-Location`, `Invoke-Expression`, captures `$LASTEXITCODE`, writes CWD via `Get-Location | Out-File`, and emits a CWD marker for the framework.
+   - Overrides `init_session()`: pwsh path skips the bash env-snapshot dance (Windows env vars propagate through `os.environ` naturally). Just writes the initial CWD file.
+   - Overrides `_run_bash()` and `_wrap_command()`: dispatch to pwsh variants when `self._shell_type == "pwsh"`, preserving the original bash code paths unchanged.
+
+2. **`tools/terminal_tool.py`** — Dynamic description:
+   - Adds `_detect_shell_for_description()`: fast, side-effect-free shell probe (no auto-install). Uses `@lru_cache(maxsize=1)`.
+   - Adds `_build_dynamic_terminal_description()`: returns `{"description": ...}` with platform-appropriate first sentence and pwsh-adapted forbidden-command references. On pwsh, replaces:
+     - `cat/head/tail` → `Get-Content/cat/type`
+     - `grep/rg/find` → `Select-String/findstr`
+     - `ls` → `Get-ChildItem/ls/dir`
+     - `echo/cat heredoc` → `echo/Set-Content/Out-File`
+     - `Pipe git output to cat` → `Pipe git output to Out-Host -Paging`
+   - Registers `dynamic_schema_overrides=_build_dynamic_terminal_description` in the terminal tool's `registry.register()` call so the description is rebuilt each time tool definitions are assembled.
+
+3. **`model_tools.py`** — Cache invalidation:
+   - Adds `_shell_fp` (current shell type) to `get_tool_definitions()` cache key. This ensures that a mid-session pwsh auto-install (which changes the terminal description) invalidates the cached tool definitions.
+
+4. **`tests/tools/test_terminal_dynamic_description.py`** — 14 tests covering:
+   - Shell detection (Windows pwsh found/not-found, non-Windows, macOS, env overrides).
+   - Description building (pwsh, Windows bash, non-Windows).
+   - pwsh-adapted command references present and Linux-only references absent.
+   - Registry integration.
+   - LRU cache behavior.
+
+**Side effects**:
+- On Windows with pwsh: all local terminal commands now execute in pwsh instead of bash. This means shell syntax (`;` not `&&`, `$env:VAR` not `$VAR`, `Get-ChildItem` not `ls` for scripts) must be pwsh-compatible. The agent's prompt already instructs it to use the active shell.
+- The `_detect_shell_for_description` LRU cache means a mid-session pwsh auto-install won't update the description until cache is cleared. Mitigation: `_find_pwsh` auto-install path should call `_detect_shell_for_description.cache_clear()`.
+- Docker/SSH/Modal backends are unaffected — they always use bash inside containers and don't go through `_resolve_shell()`.
+
+**Should we upstream?** Yes. This makes Hermes a first-class Windows citizen. The changes are modular: shell detection and dispatch follow the existing `_run_bash` / `_wrap_command` pattern, and the dynamic description reuses the existing `dynamic_schema_overrides` mechanism.
 
 ---
 

--- a/FORK_NOTES.zh-CN.md
+++ b/FORK_NOTES.zh-CN.md
@@ -23,6 +23,7 @@
 | **P-013** | `model_tools.py`, `tests/run_agent/test_repair_tool_arg_keys.py` | 在 `handle_function_call` 中增加自动参数键修复：全局别名表、工具级覆盖、模糊匹配、嵌套对象/数组递归修复，以及可选回调通知 | LLM 经常把参数名写错（如 `file`→`path`、`cmd`→`command`），此前会直接报 "unknown parameter"；该补丁在不放宽 JSON Schema 的前提下提高工具调用的容错率 | 建议上游 |
 | **P-014** | `.github/workflows/release-runtime.yml`, `tools/mcp_tool.py`, `hermes_cli/config.py`, `docs/RUNTIME_RELEASES.md`, `tests/tools/test_mcp_tool.py` | 把原生 MCP 客户端 SDK 打进冻结 runtime（安装入口后并入 `cn-desktop` extra，见 P-015；外加 `--collect-submodules/--copy-metadata mcp` + CI 断言 `mcp-*.dist-info` 存在）；并让 `discover_mcp_tools()` 在已配置 `mcp_servers` 但 SDK 缺失时输出一次 WARNING，而不是在 debug 级别静默跳过 | issue #16：desktop runtime 打包时缺少 `mcp` extra，导致 `_MCP_AVAILABLE=False`，已配置的 `mcp_servers` 不注册任何工具且 INFO 日志无任何提示。打包改动是 CN 特有，诊断日志与已知根键则是通用改进 | 打包改动 CN 特有；`mcp_tool.py` 告警与 `mcp_servers` 根键建议上游 |
 | **P-015** | `pyproject.toml`, `.github/workflows/release-runtime.yml`, `docs/RUNTIME_RELEASES.md`, `uv.lock` | 新增 `cn-desktop` 聚合 extra，把冻结 runtime 暴露的所有后端预打包（`web`、`anthropic`、`mcp`、`feishu`、`dingtalk`、`wecom`，以及微信用的 `aiohttp`/`qrcode`/`cryptography`）。发布流程改为安装 `.[cn-desktop]`，收集各 IM SDK 子模块与元数据，新增"构建环境 import 冒烟"，并断言每个后端的 `dist-info` 出现在冻结产物中 | 桌面反馈：飞书/钉钉/企微/微信适配器因 SDK（`lark-oapi`、`dingtalk-stream` 等）从未被打包、且冻结环境无法懒安装而静默降级为"不可用"。根因同 P-014，推广到所有桌面后端 | 打包 CN 特有；不上游（上游不构建这些产物） |
+| **P-016** | `tools/terminal_tool.py`, `tools/environments/local.py`, `model_tools.py`, `tests/tools/test_terminal_dynamic_description.py` | PowerShell (pwsh) 原生执行：Windows 上检测 pwsh 并将其作为主 shell，支持完整生命周期管理（spawn、wrap、init_session、cwd 跟踪）；增加运行时自适应的 terminal 工具描述，当激活 shell 为 pwsh 时自动将 Linux/bash 命令引用替换为 pwsh cmdlet；将 shell 指纹加入工具定义缓存键，使会话中期 pwsh 自动安装能刷新描述缓存 | Windows 上 agent 原本硬编码为 Git Bash；pwsh 启动更快（-NoProfile）、Windows 路径处理更原生、无需 POSIX 翻译。静态 `TERMINAL_TOOL_DESCRIPTION` 中包含的 Linux 命令引用（`cat/head/tail`、`grep/rg/find`、`echo/cat heredoc`）在 pwsh 下会产生误导 | 建议上游 |
 
 ## 发布和维护支撑
 
@@ -279,6 +280,48 @@
 **风险和约束**：冻结 runtime 体积增加 IM SDK 及其传递依赖（尤其是纯 Python 的 `alibabacloud_*` 链）。它们都是纯 Python、有跨平台 wheel/sdist——不像 `matrix` 的 `python-olm` 需要 C 工具链，那个仍刻意排除。对源码安装无影响。
 
 **是否上游**：否。上游不构建这些 PyInstaller 产物，`cn-desktop` extra 与打包均为 CN runtime 特有。
+### P-014：PowerShell (pwsh) 原生执行 + 运行时自适应终端工具描述
+
+**现象**：Windows 上 agent 硬编码使用 Git Bash。PowerShell 7 (pwsh) 启动更快（`-NoProfile` 跳过 profile 加载），原生处理 Windows 路径（无需 `/c/foo` 翻译），是现代 Windows 的默认 shell。此外，terminal 工具的静态 `TERMINAL_TOOL_DESCRIPTION` 包含 Linux/bash 命令引用（`cat/head/tail`、`grep/rg/find`、`echo/cat heredoc`、`Pipe git output to cat`），这些命令在原生 pwsh 中不存在——LLM 要么尝试执行失败，要么不知道应避开哪些 pwsh 等价命令。
+
+**原因**：上游 `LocalEnvironment` 只支持 bash。terminal 工具描述是硬编码的静态字符串，假定 Linux 环境。
+
+**改动内容**：
+
+1. **`tools/environments/local.py`** — Shell 检测与 pwsh 执行：
+   - 新增 `_resolve_shell()`：检测 pwsh vs bash。支持 `HERMES_SHELL_TYPE`（auto/pwsh/bash）和 `HERMES_PWSH_PATH` 环境变量覆盖。pwsh 不可用时回退到 Git Bash。复用已有的 `_find_pwsh`（含自动安装）来自 `tools/environments/_find_pwsh.py`。
+   - `LocalEnvironment.__init__` 调用 `_resolve_shell()` 并保存 `self._shell_type` / `self._shell_path`。
+   - 新增 `_run_pwsh()`：使用 `-NoProfile -Command <script>` 启动 pwsh，处理 stdin 管道和 Windows creation flags。
+   - 新增 `_wrap_command_pwsh()`：构建 PowerShell 脚本，执行 `Set-Location`、`Invoke-Expression`，捕获 `$LASTEXITCODE`，通过 `Get-Location | Out-File` 写入 CWD，并输出框架所需的 CWD 标记。
+   - 覆写 `init_session()`：pwsh 路径跳过 bash 环境快照（Windows 环境变量通过 `os.environ` 自然继承），仅写入初始 CWD 文件。
+   - 覆写 `_run_bash()` 和 `_wrap_command()`：当 `self._shell_type == "pwsh"` 时分发到 pwsh 变体，保持原有 bash 代码路径不变。
+
+2. **`tools/terminal_tool.py`** — 动态描述：
+   - 新增 `_detect_shell_for_description()`：快速、无副作用的 shell 探测（不触发自动安装）。使用 `@lru_cache(maxsize=1)` 缓存。
+   - 新增 `_build_dynamic_terminal_description()`：返回 `{"description": ...}`，包含平台适配的首句和 pwsh 专用的禁用手命令引用。在 pwsh 下替换：
+     - `cat/head/tail` → `Get-Content/cat/type`
+     - `grep/rg/find` → `Select-String/findstr`
+     - `ls` → `Get-ChildItem/ls/dir`
+     - `echo/cat heredoc` → `echo/Set-Content/Out-File`
+     - `Pipe git output to cat` → `Pipe git output to Out-Host -Paging`
+   - 在 terminal 工具的 `registry.register()` 调用中注册 `dynamic_schema_overrides=_build_dynamic_terminal_description`，使每次组装工具定义时描述都会重新生成。
+
+3. **`model_tools.py`** — 缓存失效：
+   - 将 `_shell_fp`（当前 shell 类型）加入 `get_tool_definitions()` 缓存键。确保会话中期 pwsh 自动安装（会改变 terminal 描述）能使缓存的工具定义失效。
+
+4. **`tests/tools/test_terminal_dynamic_description.py`** — 14 个测试覆盖：
+   - Shell 检测（Windows pwsh 存在/不存在、非 Windows、macOS、环境变量覆盖）。
+   - 描述构建（pwsh、Windows bash、非 Windows）。
+   - pwsh 适配命令引用存在且 Linux 原始引用不存在。
+   - Registry 集成。
+   - LRU 缓存行为。
+
+**风险和约束**：
+- Windows 上有 pwsh 时：所有本地 terminal 命令现在在 pwsh 中执行而非 bash。这意味着 shell 语法（`;` 而非 `&&`、`$env:VAR` 而非 `$VAR`、脚本应使用 `Get-ChildItem` 而非 `ls`）必须是 pwsh 兼容的。Agent 的 prompt 已指示使用当前活动的 shell。
+- `_detect_shell_for_description` LRU 缓存意味着会话中期 pwsh 自动安装不会更新描述，直到缓存被清除。缓解方案：`_find_pwsh` 自动安装路径应调用 `_detect_shell_for_description.cache_clear()`。
+- Docker/SSH/Modal 后端不受影响——它们始终在容器内使用 bash，不经过 `_resolve_shell()`。
+
+**是否上游**：建议上游。这使 Hermes 成为 Windows 一等公民。改动是模块化的：shell 检测和分发遵循已有的 `_run_bash` / `_wrap_command` 模式，动态描述复用已有的 `dynamic_schema_overrides` 机制。
 
 ---
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -522,6 +522,14 @@ def get_tool_definitions(
             cfg_fp = (cfg_stat.st_mtime_ns, cfg_stat.st_size)
         except (FileNotFoundError, OSError, ImportError):
             cfg_fp = None
+        # Include current shell type in the cache key so that a mid-session
+        # auto-install of pwsh (which changes the terminal tool's dynamic
+        # description) invalidates the cached tool definitions.
+        try:
+            from tools.terminal_tool import _detect_shell_for_description
+            _shell_fp = _detect_shell_for_description()
+        except Exception:
+            _shell_fp = "bash"
         cache_key = (
             frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
             frozenset(disabled_toolsets) if disabled_toolsets else None,
@@ -529,6 +537,7 @@ def get_tool_definitions(
             cfg_fp,
             bool(os.environ.get("HERMES_KANBAN_TASK")),
             bool(skip_tool_search_assembly),
+            _shell_fp,
         )
         cached = _tool_defs_cache.get(cache_key)
         if cached is not None:

--- a/tools/environments/_find_pwsh.py
+++ b/tools/environments/_find_pwsh.py
@@ -1,0 +1,134 @@
+"""Find the PowerShell 7 (pwsh) executable on Windows.
+
+Ported from the KIMI agent discovery logic.  Provides a cached,
+multi-strategy lookup with silent auto-install fallback.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _get_config_dir() -> Path:
+    """Return the config directory for cached shell paths."""
+    try:
+        from hermes_constants import get_hermes_home
+        return get_hermes_home() / "config"
+    except Exception:
+        return Path.home() / ".hermes" / "config"
+
+
+@functools.lru_cache(maxsize=1)
+def find_pwsh() -> str | None:
+    """Find the system PowerShell executable.
+
+    On Windows, prioritises ``pwsh`` (PowerShell 7+) over ``powershell``
+    (Windows PowerShell 5.1).  Falls back to silent auto-install when
+    pwsh is not found.
+
+    Returns ``None`` on non-Windows or when all strategies fail.
+    """
+    import sys
+
+    if sys.platform != "win32":
+        return None
+
+    config_dir = _get_config_dir()
+    cache_file = config_dir / "pwsh.txt"
+
+    # Strategy 0: read cached pwsh path
+    if cache_file.is_file():
+        cached_path = cache_file.read_text().strip()
+        if cached_path and Path(cached_path).exists():
+            logger.debug("find_pwsh: using cached path %s", cached_path)
+            return cached_path
+        # Stale cache -- remove it
+        try:
+            cache_file.unlink()
+        except Exception:
+            pass
+
+    # Strategy 1: pwsh (PowerShell 7+) via PATH
+    pwsh_path = shutil.which("pwsh")
+    if pwsh_path:
+        resolved = str(Path(pwsh_path).resolve())
+        logger.debug("find_pwsh: found on PATH: %s", resolved)
+        return resolved
+
+    # Strategy 2: pwsh.exe via PATH
+    pwsh_path = shutil.which("pwsh.exe")
+    if pwsh_path:
+        resolved = str(Path(pwsh_path).resolve())
+        logger.debug("find_pwsh: found pwsh.exe on PATH: %s", resolved)
+        return resolved
+
+    # Strategy 3: where.exe command for pwsh
+    try:
+        r = subprocess.run(
+            ["where.exe", "pwsh.exe"],
+            capture_output=True, text=True, check=True,
+        )
+        first = r.stdout.strip().splitlines()[0].strip()
+        if first:
+            resolved = str(Path(first).resolve())
+            logger.debug("find_pwsh: found via where.exe: %s", resolved)
+            return resolved
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    # Strategy 4: Common paths fallback for pwsh
+    candidates = [
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        r"C:\Program Files (x86)\PowerShell\7\pwsh.exe",
+    ]
+    for candidate in candidates:
+        if Path(candidate).exists():
+            logger.debug("find_pwsh: found at common path: %s", candidate)
+            return str(Path(candidate).resolve())
+
+    # Also check LOCALAPPDATA portable install
+    local_pwsh = (
+        Path(os.environ.get("LOCALAPPDATA", str(Path.home())))
+        / "PowerShell" / "7" / "pwsh.exe"
+    )
+    if local_pwsh.exists():
+        logger.debug("find_pwsh: found local portable: %s", local_pwsh)
+        return str(local_pwsh.resolve())
+
+    # Strategy 5: Auto-install fallback
+    try:
+        from tools.environments._install_pwsh import install_pwsh
+
+        logger.info(
+            "PowerShell 7 not found – attempting silent auto-install ..."
+        )
+        pwsh_path = install_pwsh()
+        if pwsh_path and Path(pwsh_path).exists():
+            # Persist to cache so subsequent calls skip detection + install
+            config_dir.mkdir(parents=True, exist_ok=True)
+            cache_file.write_text(pwsh_path, encoding="utf-8")
+            # Update in-process PATH so subprocesses see it immediately
+            bin_dir = str(Path(pwsh_path).parent)
+            current_path = os.environ.get("PATH", "")
+            if bin_dir not in current_path.split(os.pathsep):
+                os.environ["PATH"] = bin_dir + os.pathsep + current_path
+            # Invalidate shell-detection caches so the terminal tool
+            # description reflects pwsh availability going forward.
+            try:
+                from tools.terminal_tool import _detect_shell_for_description
+                _detect_shell_for_description.cache_clear()
+            except Exception:
+                pass
+            logger.info("PowerShell 7 auto-installed at: %s", pwsh_path)
+            return pwsh_path
+    except Exception as exc:
+        logger.debug("find_pwsh: auto-install failed: %s", exc)
+
+    return None

--- a/tools/environments/_install_pwsh.py
+++ b/tools/environments/_install_pwsh.py
@@ -1,0 +1,368 @@
+"""Auto-install PowerShell 7 (pwsh) silently on Windows.
+
+Ported from the KIMI agent install logic. Provides a silent fallback
+that downloads PowerShell 7 when the local terminal backend wants to
+use pwsh but can't find it.
+
+Strategy (in priority order):
+1. WinGet (official Microsoft recommendation)
+2. MSI direct download from GitHub latest release (silent msiexec install)
+3. ZIP portable download from GitHub latest release (no admin required)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ============================================================
+# Global configuration
+# ============================================================
+_DEFAULT_ZIP_INSTALL_DIR = Path(
+    os.environ.get("LOCALAPPDATA", str(Path.home()))) / "PowerShell" / "7"
+"""Default install directory for the ZIP portable extraction strategy."""
+
+_GITHUB_API_URL = (
+    "https://api.github.com/repos/PowerShell/PowerShell/releases/latest"
+)
+"""GitHub API endpoint for the latest PowerShell release."""
+
+_FALLBACK_VERSION = "7.6.2"
+"""Hardcoded fallback version if GitHub API query fails."""
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _is_windows() -> bool:
+    return sys.platform == "win32"
+
+
+def _run(cmd: list[str], timeout: int = 600) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess and return the result (stdout/stderr captured as text)."""
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+def _pwsh_found(install_dir: str | None = None) -> bool:
+    """Return ``True`` if ``pwsh.exe`` is available.
+
+    When *install_dir* is given, checks that directory first
+    (looking for ``pwsh.exe``).  Falls back to checking
+    PATH when *install_dir* is ``None``.
+    """
+    if install_dir:
+        return (Path(install_dir) / "pwsh.exe").exists()
+    return shutil.which("pwsh") is not None or shutil.which("pwsh.exe") is not None
+
+
+def _get_latest_release_info() -> dict | None:
+    """Fetch the latest PowerShell release info from GitHub API.
+
+    Returns the parsed JSON data on success, or ``None`` on failure.
+    """
+    try:
+        logger.info("Querying GitHub API for latest PowerShell release ...")
+        req = urllib.request.Request(
+            _GITHUB_API_URL,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "hermes-installer",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:
+        logger.warning("GitHub API query failed: %s", exc)
+        return None
+
+
+def _get_version_from_release(release_info: dict) -> str:
+    """Extract the version string from a GitHub release info dict.
+
+    Strips the leading 'v' from ``tag_name`` (e.g. ``v7.6.2`` → ``7.6.2``).
+    """
+    tag = release_info.get("tag_name", "")
+    return tag.lstrip("v")
+
+
+def _find_asset(release_info: dict, suffix: str) -> dict | None:
+    """Find an asset whose name ends with *suffix* from the release assets list."""
+    assets = release_info.get("assets", [])
+    for asset in assets:
+        name = asset.get("name", "")
+        if name.endswith(suffix):
+            return asset
+    return None
+
+
+def _ensure_in_user_path(dirpath: str) -> None:
+    """Add *dirpath* to the current user's PATH environment variable (persistent)."""
+    import winreg
+
+    try:
+        key = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Environment",
+            0,
+            winreg.KEY_READ | winreg.KEY_WRITE,
+        )
+    except FileNotFoundError:
+        return
+    try:
+        path_val, _ = winreg.QueryValueEx(key, "Path")
+    except FileNotFoundError:
+        path_val = ""
+    entries = [p.strip() for p in path_val.split(";") if p.strip()]
+    if dirpath in entries:
+        winreg.CloseKey(key)
+        return
+    entries.append(dirpath)
+    new_path = ";".join(entries)
+    winreg.SetValueEx(key, "Path", 0, winreg.REG_EXPAND_SZ, new_path)
+    winreg.CloseKey(key)
+
+
+def _download_file(url: str, dest: Path) -> None:
+    """Download *url* to *dest*, with a progress indicator."""
+    logger.info("Downloading %s ...", dest.name)
+
+    def _report(block_num: int, block_size: int, total_size: int) -> None:
+        if total_size > 0:
+            pct = min(100, int(block_num * block_size * 100 / total_size))
+            sys.stdout.write(f"\r  {pct}%")
+            sys.stdout.flush()
+
+    urllib.request.urlretrieve(url, str(dest), _report)
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+# ---------------------------------------------------------------------------
+# strategy implementations
+# ---------------------------------------------------------------------------
+
+def _try_winget() -> bool:
+    """Install PowerShell 7 via WinGet (preferred, official Microsoft channel)."""
+    if not shutil.which("winget"):
+        return False
+    try:
+        logger.info("Installing PowerShell 7 via WinGet ...")
+        _run(
+            [
+                "winget",
+                "install",
+                "--id",
+                "Microsoft.PowerShell",
+                "--source",
+                "winget",
+                "--accept-package-agreements",
+                "--accept-source-agreements",
+                "--silent",
+            ],
+            timeout=600,
+        )
+        return _pwsh_found()
+    except Exception as exc:
+        logger.warning("WinGet install failed: %s", exc)
+        return False
+
+
+def _try_msi(install_dir: str | None = None) -> bool:
+    """Download the latest PowerShell MSI installer and run it silently.
+
+    The MSI is installed system-wide (requires admin privileges).
+    """
+    release_info = _get_latest_release_info()
+    if release_info is None:
+        logger.info("Falling back to hardcoded version for MSI download.")
+        version = _FALLBACK_VERSION
+        msi_url = (
+            f"https://github.com/PowerShell/PowerShell/releases/download/"
+            f"v{version}/PowerShell-{version}-win-x64.msi"
+        )
+    else:
+        version = _get_version_from_release(release_info)
+        asset = _find_asset(release_info, "-win-x64.msi")
+        if asset is None:
+            logger.warning("No MSI asset found in latest release.")
+            return False
+        msi_url = asset["browser_download_url"]
+
+    msi_name = f"PowerShell-{version}-win-x64.msi"
+    msi_path = Path(tempfile.gettempdir()) / msi_name
+
+    # --- download ---
+    try:
+        _download_file(msi_url, msi_path)
+    except Exception as exc:
+        logger.warning("Download failed: %s", exc)
+        return False
+
+    # --- install ---
+    try:
+        logger.info("Running silent MSI installer ...")
+        cmd = [
+            "msiexec.exe",
+            "/i",
+            str(msi_path),
+            "/quiet",
+            "/norestart",
+        ]
+        if install_dir:
+            cmd.append(f'INSTALLDIR="{install_dir}"')
+        _run(cmd, timeout=600)
+    except subprocess.TimeoutExpired:
+        logger.warning("MSI installer timed out.")
+    except Exception as exc:
+        logger.warning("MSI installer error: %s", exc)
+    finally:
+        # --- clean up ---
+        msi_path.unlink(missing_ok=True)
+
+    return _pwsh_found()
+
+
+def _try_zip(install_dir: str | None = None) -> bool:
+    """Download the latest PowerShell ZIP archive and extract it.
+
+    This strategy does NOT require admin privileges.
+    """
+    release_info = _get_latest_release_info()
+    if release_info is None:
+        logger.info("Falling back to hardcoded version for ZIP download.")
+        version = _FALLBACK_VERSION
+        zip_url = (
+            f"https://github.com/PowerShell/PowerShell/releases/download/"
+            f"v{version}/PowerShell-{version}-win-x64.zip"
+        )
+    else:
+        version = _get_version_from_release(release_info)
+        asset = _find_asset(release_info, "-win-x64.zip")
+        if asset is None:
+            logger.warning("No ZIP asset found in latest release.")
+            return False
+        zip_url = asset["browser_download_url"]
+
+    zip_name = f"PowerShell-{version}-win-x64.zip"
+    zip_path = Path(tempfile.gettempdir()) / zip_name
+
+    target = Path(install_dir) if install_dir else _DEFAULT_ZIP_INSTALL_DIR
+    target.mkdir(parents=True, exist_ok=True)
+
+    # --- download ---
+    try:
+        _download_file(zip_url, zip_path)
+    except Exception as exc:
+        logger.warning("Download failed: %s", exc)
+        return False
+
+    # --- extract ---
+    try:
+        logger.info("Extracting to %s ...", target)
+        shutil.unpack_archive(str(zip_path), str(target))
+    except Exception as exc:
+        logger.warning("Extraction error: %s", exc)
+    finally:
+        zip_path.unlink(missing_ok=True)
+
+    # --- verify ---
+    if _pwsh_found(str(target)):
+        _ensure_in_user_path(str(target))
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# public API
+# ---------------------------------------------------------------------------
+
+def install_pwsh(
+    install_dir: str | None = None,
+    *,
+    add_to_path: bool = True,
+    timeout: int = 600,
+) -> str | None:
+    """Silently install PowerShell 7 for Windows.
+
+    Tries, in order:
+      1. WinGet (``winget install Microsoft.PowerShell --silent``).
+      2. MSI direct download from GitHub latest release (requires admin).
+      3. ZIP portable download from GitHub latest release (no admin).
+
+    Parameters
+    ----------
+    install_dir:
+        Target directory.  For the ZIP strategy defaults to
+        ``%LOCALAPPDATA%\\PowerShell\\7``.  For MSI it influences the
+        ``INSTALLDIR`` property.
+    add_to_path:
+        Whether to append the install directory to the user PATH.
+    timeout:
+        Seconds to wait for each install subprocess.
+
+    Returns
+    -------
+    The absolute path to ``pwsh.exe`` on success, or ``None`` on failure.
+    """
+    if not _is_windows():
+        logger.debug("install_pwsh: this script only supports Windows.")
+        return None
+
+    # Already installed?
+    if _pwsh_found(install_dir):
+        where = f"at {install_dir}" if install_dir else "on PATH"
+        logger.info("PowerShell 7 is already installed %s.", where)
+        pwsh_path = (
+            str(Path(install_dir) / "pwsh.exe")
+            if install_dir
+            else shutil.which("pwsh") or shutil.which("pwsh.exe")
+        )
+        if pwsh_path and add_to_path:
+            bin_dir = str(Path(pwsh_path).parent)
+            _ensure_in_user_path(bin_dir)
+        return pwsh_path
+
+    strategies: list[tuple[str, object]] = [
+        ("winget", _try_winget),
+        ("MSI direct download", lambda: _try_msi(install_dir)),
+        ("ZIP portable", lambda: _try_zip(install_dir)),
+    ]
+
+    for name, fn in strategies:
+        logger.info("Trying PowerShell 7 install: %s ...", name)
+        try:
+            ok = fn()  # type: ignore[operator]
+        except Exception as exc:
+            logger.warning("  %s raised: %s", name, exc)
+            ok = False
+        if ok and _pwsh_found():
+            logger.info("PowerShell 7 installed successfully via %s.", name)
+            pwsh_path = shutil.which("pwsh") or shutil.which("pwsh.exe")
+            # For ZIP strategy, pwsh may not be on PATH yet; check install_dir
+            if not pwsh_path and install_dir:
+                candidate = Path(install_dir) / "pwsh.exe"
+                if candidate.exists():
+                    pwsh_path = str(candidate)
+            # Also check default ZIP path
+            if not pwsh_path:
+                candidate = _DEFAULT_ZIP_INSTALL_DIR / "pwsh.exe"
+                if candidate.exists():
+                    pwsh_path = str(candidate)
+            if pwsh_path and add_to_path:
+                bin_dir = str(Path(pwsh_path).parent)
+                _ensure_in_user_path(bin_dir)
+            return pwsh_path
+        logger.info("  %s did not succeed.", name)
+
+    logger.warning("All PowerShell 7 installation strategies failed.")
+    return None

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -17,6 +17,9 @@ from hermes_cli._subprocess_compat import windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
 
+# Lazy-imported when needed on Windows
+_find_pwsh = None
+
 logger = logging.getLogger(__name__)
 
 
@@ -398,6 +401,57 @@ def _find_bash() -> str:
     )
 
 
+def _resolve_shell() -> tuple[str, str]:
+    """Determine which shell to use for local command execution.
+
+    On Windows: try PowerShell 7 (pwsh) first, fall back to Git Bash.
+    On non-Windows: always use bash.
+
+    Env overrides:
+      ``HERMES_SHELL_TYPE`` — ``"pwsh"``, ``"bash"``, or ``"auto"`` (default).
+      ``HERMES_PWSH_PATH`` — explicit path to pwsh.exe.
+      ``HERMES_GIT_BASH_PATH`` — explicit path to bash.exe (existing).
+
+    Returns ``(shell_type, shell_path)`` where *shell_type* is ``"pwsh"``
+    or ``"bash"``.
+    """
+    shell_type = os.environ.get("HERMES_SHELL_TYPE", "auto").strip().lower() or "auto"
+
+    if _IS_WINDOWS and shell_type in ("pwsh", "powershell", "auto"):
+        # Check explicit pwsh path override first
+        explicit_pwsh = os.environ.get("HERMES_PWSH_PATH", "").strip()
+        if explicit_pwsh and os.path.isfile(explicit_pwsh):
+            logger.info("Using pwsh from HERMES_PWSH_PATH: %s", explicit_pwsh)
+            return ("pwsh", explicit_pwsh)
+
+        # Try discovery (with auto-install fallback)
+        try:
+            global _find_pwsh
+            if _find_pwsh is None:
+                from tools.environments._find_pwsh import find_pwsh as _fp
+                _find_pwsh = _fp
+            pwsh_path = _find_pwsh()
+            if pwsh_path:
+                logger.info("Selected shell: pwsh at %s", pwsh_path)
+                return ("pwsh", pwsh_path)
+        except Exception as exc:
+            logger.debug("pwsh discovery failed: %s", exc)
+
+        if shell_type == "pwsh":
+            raise RuntimeError(
+                "HERMES_SHELL_TYPE=pwsh but PowerShell 7 could not be found. "
+                "Set HERMES_PWSH_PATH or install PowerShell 7."
+            )
+
+    # Fall back to bash
+    bash_path = _find_bash()
+    if bash_path:
+        logger.info("Selected shell: bash at %s", bash_path)
+        return ("bash", bash_path)
+
+    raise RuntimeError("No usable shell found.")
+
+
 # Backward compat — process_registry.py imports this name
 _find_shell = _find_bash
 
@@ -546,8 +600,12 @@ def _prepend_shell_init(cmd_string: str, files: list[str]) -> str:
 class LocalEnvironment(BaseEnvironment):
     """Run commands directly on the host machine.
 
-    Spawn-per-call: every execute() spawns a fresh bash process.
-    Session snapshot preserves env vars across calls.
+    Spawn-per-call: every execute() spawns a fresh shell process.
+    On Windows, uses PowerShell 7 (pwsh) when available, falling back
+    to Git Bash.  On other platforms, uses bash.
+
+    Session snapshot preserves env vars across calls (bash only;
+    Windows env vars propagate naturally through ``os.environ``).
     CWD persists via file-based read after each command.
     """
 
@@ -555,6 +613,7 @@ class LocalEnvironment(BaseEnvironment):
         if cwd:
             cwd = os.path.expanduser(cwd)
         super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
+        self._shell_type, self._shell_path = _resolve_shell()
         self.init_session()
 
     def get_temp_dir(self) -> str:
@@ -605,9 +664,152 @@ class LocalEnvironment(BaseEnvironment):
 
         return "/tmp"
 
+    # ------------------------------------------------------------------
+    # pwsh-specific methods
+    # ------------------------------------------------------------------
+
+    def _run_pwsh(self, cmd_string: str, *, login: bool = False,
+                  timeout: int = 120,
+                  stdin_data: str | None = None) -> subprocess.Popen:
+        """Spawn a pwsh process to run *cmd_string*.
+
+        Uses ``-NoProfile`` for speed (profile loading is slow in pwsh).
+        Windows paths are handled natively — no backslash conversion needed.
+        """
+        args = [self._shell_path, "-NoProfile", "-Command", cmd_string]
+        run_env = _make_run_env(self.env)
+        safe_cwd = _resolve_safe_cwd(self.cwd)
+        if safe_cwd != self.cwd:
+            # On Windows, _resolve_safe_cwd calls os.path.normpath which
+            # converts forward slashes to backslashes.  Compare normalized
+            # forms so a benign slash-normalization doesn't trigger a warning.
+            normalized_self = os.path.normpath(
+                _msys_to_windows_path(self.cwd) if _IS_WINDOWS else self.cwd
+            )
+            if safe_cwd != normalized_self:
+                logger.warning(
+                    "LocalEnvironment cwd %r is missing on disk; "
+                    "falling back to %r so terminal commands keep working.",
+                    self.cwd,
+                    safe_cwd,
+                )
+            self.cwd = safe_cwd
+
+        _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
+
+        proc = subprocess.Popen(
+            args,
+            text=True,
+            env=run_env,
+            encoding="utf-8",
+            errors="replace",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+            cwd=safe_cwd,
+            **_popen_kwargs,
+        )
+
+        if stdin_data is not None:
+            _pipe_stdin(proc, stdin_data)
+
+        return proc
+
+    def _wrap_command_pwsh(self, command: str, cwd: str) -> str:
+        """Build a PowerShell script that cd's, runs the command, and emits
+        CWD marker + exit code.
+
+        PowerShell equivalents:
+          ``cd``      → ``Set-Location`` (``cd`` also works in pwsh)
+          ``$?``      → ``$LASTEXITCODE``
+          ``pwd -P``  → ``Get-Location``
+        """
+        # Escape single quotes for PowerShell: double them
+        escaped = command.replace("'", "''")
+        quoted_cwd = cwd.replace("'", "''")
+        quoted_cwd_file = self._cwd_file.replace("'", "''")
+
+        marker = self._cwd_marker
+
+        # Build a PowerShell script.  We use ``Invoke-Expression`` to run
+        # the user's command (similar to bash ``eval``).  ``$LASTEXITCODE``
+        # captures the exit code of the last external command.
+        parts = [
+            # Suppress errors, cd to target
+            f"$ErrorActionPreference = 'Continue'",
+            f"Set-Location -LiteralPath '{quoted_cwd}' -ErrorAction SilentlyContinue",
+            f"if ($?) {{ Set-Location -LiteralPath '{quoted_cwd}' }} else {{ exit 126 }}",
+            # Run the command
+            f"Invoke-Expression '{escaped}'",
+            f"$hermes_ec = $LASTEXITCODE",
+            # Write CWD to temp file
+            f"(Get-Location).Path | Out-File -Encoding utf8 -FilePath '{quoted_cwd_file}'",
+            # Emit CWD marker
+            f"$cwd = (Get-Location).Path",
+            f"Write-Output ''",
+            f"Write-Output '{marker}' + $cwd + '{marker}'",
+            # Exit with captured code
+            f"exit $hermes_ec",
+        ]
+
+        return "\n".join(parts)
+
+    # ------------------------------------------------------------------
+    # init_session override (handles both pwsh and bash)
+    # ------------------------------------------------------------------
+
+    def init_session(self):
+        """Capture shell environment into a snapshot file.
+
+        For **pwsh**: skip the snapshot dance — Windows env vars persist
+        through ``os.environ`` inheritance naturally.  Just write the
+        initial CWD and mark snapshot as not-ready (commands run fresh
+        with ``-NoProfile`` for speed).
+
+        For **bash**: unchanged — captures env vars, functions, aliases
+        into a snapshot file that subsequent commands source.
+        """
+        if self._shell_type == "pwsh":
+            # Simple CWD marker write — no snapshot needed for pwsh.
+            self._snapshot_ready = False
+            try:
+                cwd_path = self.cwd
+                if _IS_WINDOWS:
+                    cwd_path = os.path.normpath(cwd_path)
+                Path(self._cwd_file).parent.mkdir(parents=True, exist_ok=True)
+                Path(self._cwd_file).write_text(cwd_path, encoding="utf-8")
+            except Exception as exc:
+                logger.warning(
+                    "init_session (pwsh) failed to write CWD file: %s", exc
+                )
+            logger.info(
+                "pwsh session ready (session=%s, cwd=%s)",
+                self._session_id,
+                self.cwd,
+            )
+            return
+
+        # --- bash path (unchanged from BaseEnvironment) ---
+        return super().init_session()
+
+    # ------------------------------------------------------------------
+    # _run_bash override (dispatches to _run_pwsh when active)
+    # ------------------------------------------------------------------
+
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
+        """Spawn a shell process to run *cmd_string*.
+
+        Dispatches to ``_run_pwsh()`` when the active shell is pwsh,
+        otherwise uses the existing bash path (unchanged behaviour).
+        """
+        if self._shell_type == "pwsh":
+            return self._run_pwsh(
+                cmd_string, login=login, timeout=timeout, stdin_data=stdin_data
+            )
+
+        # --- existing bash path (unchanged) ---
         bash = _find_bash()
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /
@@ -675,6 +877,20 @@ class LocalEnvironment(BaseEnvironment):
             _pipe_stdin(proc, stdin_data)
 
         return proc
+
+    # ------------------------------------------------------------------
+    # _wrap_command override (dispatches to pwsh wrapping when active)
+    # ------------------------------------------------------------------
+
+    def _wrap_command(self, command: str, cwd: str) -> str:
+        """Build the shell script wrapper for command execution.
+
+        Dispatches to ``_wrap_command_pwsh()`` when the active shell is
+        pwsh, otherwise uses the base bash wrapping.
+        """
+        if self._shell_type == "pwsh":
+            return self._wrap_command_pwsh(command, cwd)
+        return super()._wrap_command(command, cwd)
 
     def _kill_process(self, proc):
         """Kill the entire process group (all children)."""

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -825,6 +825,7 @@ from tools.environments.ssh import SSHEnvironment as _SSHEnvironment
 from tools.environments.docker import DockerEnvironment as _DockerEnvironment
 from tools.environments.modal import ModalEnvironment as _ModalEnvironment
 from tools.environments.managed_modal import ManagedModalEnvironment as _ManagedModalEnvironment
+from tools.environments._find_pwsh import find_pwsh
 from tools.managed_tool_gateway import is_managed_tool_gateway_ready
 import sys
 
@@ -855,11 +856,17 @@ Do NOT use vim/nano/interactive tools without pty=true — they hang without a p
 
 @functools.lru_cache(maxsize=1)
 def _detect_shell_for_description() -> str:
-    """Detect shell type for description purposes (no side effects).
+    """Detect shell type for description purposes.
 
-    Returns ``"pwsh"``, ``"bash"``, or ``"bash"`` (default).
-    Does NOT auto-install pwsh — just probes what is available.
+    Returns ``"pwsh"`` or ``"bash"``.
+
+    On Windows with ``HERMES_SHELL_TYPE`` set to ``"auto"`` (default) or
+    ``"pwsh"``, calls ``find_pwsh()`` which probes PATH and falls back to
+    silent auto-install of PowerShell 7.  Falls back to ``"bash"`` only
+    when ``HERMES_SHELL_TYPE=auto`` and all pwsh strategies fail.
+
     Cached via ``@lru_cache`` so repeated calls are essentially free.
+    The cache returns the post-install result after the first call.
     """
     if platform.system() != "Windows":
         return "bash"
@@ -867,16 +874,24 @@ def _detect_shell_for_description() -> str:
     # Check HERMES_SHELL_TYPE override
     shell_type = os.environ.get("HERMES_SHELL_TYPE", "auto").strip().lower() or "auto"
 
-    if shell_type in ("pwsh", "powershell"):
-        return "pwsh"
     if shell_type == "bash":
         return "bash"
 
-    # Auto: probe pwsh existence (cheap — just PATH lookup, no auto-install)
-    pwsh = shutil.which("pwsh") or shutil.which("pwsh.exe")
-    if pwsh:
-        return "pwsh"
+    # pwsh / powershell / auto: probe via find_pwsh (includes auto-install)
+    if shell_type in ("pwsh", "powershell", "auto"):
+        pwsh_path = find_pwsh()
+        if pwsh_path:
+            return "pwsh"
 
+        # Explicit pwsh requested but unavailable — still report pwsh;
+        # _resolve_shell() in local.py will raise a clear RuntimeError.
+        if shell_type == "pwsh":
+            return "pwsh"
+
+        # Auto mode — fall back to bash, consistent with _resolve_shell()
+        return "bash"
+
+    # Unknown shell_type (safety net — should not happen with valid config)
     return "bash"
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -31,6 +31,7 @@ Usage:
     result = terminal_tool("python server.py", background=True)
 """
 
+import functools
 import importlib.util
 import json
 import logging
@@ -850,6 +851,87 @@ PTY mode: Set pty=true for interactive CLI tools (Codex, Claude Code, Python REP
 
 Do NOT use vim/nano/interactive tools without pty=true — they hang without a pseudo-terminal. Pipe git output to cat if it might page.
 """
+
+
+@functools.lru_cache(maxsize=1)
+def _detect_shell_for_description() -> str:
+    """Detect shell type for description purposes (no side effects).
+
+    Returns ``"pwsh"``, ``"bash"``, or ``"bash"`` (default).
+    Does NOT auto-install pwsh — just probes what is available.
+    Cached via ``@lru_cache`` so repeated calls are essentially free.
+    """
+    if platform.system() != "Windows":
+        return "bash"
+
+    # Check HERMES_SHELL_TYPE override
+    shell_type = os.environ.get("HERMES_SHELL_TYPE", "auto").strip().lower() or "auto"
+
+    if shell_type in ("pwsh", "powershell"):
+        return "pwsh"
+    if shell_type == "bash":
+        return "bash"
+
+    # Auto: probe pwsh existence (cheap — just PATH lookup, no auto-install)
+    pwsh = shutil.which("pwsh") or shutil.which("pwsh.exe")
+    if pwsh:
+        return "pwsh"
+
+    return "bash"
+
+
+def _build_dynamic_terminal_description() -> dict:
+    """Return dynamic schema overrides reflecting the actual shell in use.
+
+    Called lazily each time ``registry.get_definitions()`` assembles the
+    terminal tool schema, so the description always matches the shell
+    the agent will actually execute against.
+    """
+    shell_type = _detect_shell_for_description()
+
+    if shell_type == "pwsh":
+        platform_env = "Execute powershell commands on a Windows PowerShell (pwsh) environment"
+    elif shell_type == "bash" and platform.system() == "Windows":
+        platform_env = "Execute shell commands on a Windows Git Bash environment"
+    else:
+        platform_env = "Execute shell commands on a Linux environment"
+
+    # Replace the hardcoded "Linux environment" with the real platform
+    new_description = TERMINAL_TOOL_DESCRIPTION.replace(
+        "Execute shell commands on a Linux environment.",
+        platform_env
+    )
+
+    # ------------------------------------------------------------------
+    # For PowerShell, also adapt Linux/bash-specific command references
+    # so the agent sees cmdlets it might actually be tempted to misuse.
+    # The core guidance ("use agent tools instead of shell commands")
+    # stays the same; only the example commands change.
+    # ------------------------------------------------------------------
+    if shell_type == "pwsh":
+        new_description = new_description.replace(
+            "Do NOT use cat/head/tail to read files",
+            "Do NOT use Get-Content/cat/type to read files",
+        )
+        new_description = new_description.replace(
+            "Do NOT use grep/rg/find to search",
+            "Do NOT use Select-String/findstr to search",
+        )
+        new_description = new_description.replace(
+            "Do NOT use ls to list directories",
+            "Do NOT use Get-ChildItem/ls/dir to list directories",
+        )
+        new_description = new_description.replace(
+            "Do NOT use echo/cat heredoc to create files",
+            "Do NOT use echo/Set-Content/Out-File to create files",
+        )
+        new_description = new_description.replace(
+            "Pipe git output to cat if it might page.",
+            "Pipe git output to Out-Host -Paging if it might page.",
+        )
+
+    return {"description": new_description}
+
 
 # Global state for environment lifecycle management
 _active_environments: Dict[str, Any] = {}
@@ -2608,4 +2690,5 @@ registry.register(
     check_fn=check_terminal_requirements,
     emoji="💻",
     max_result_size_chars=100_000,
+    dynamic_schema_overrides=_build_dynamic_terminal_description,
 )


### PR DESCRIPTION
## 概述

将 **@MaxwellGeng** 在 `dev-fix` 分支上新增的功能合并到 `main`:**Windows PowerShell (pwsh) 原生执行 + 终端工具描述运行时自适应 + 终端工具额外检查**。

> 作者署名保留为 @MaxwellGeng（cherry-pick 保留 author）。`dev-fix` 已落后 `main` **744 个提交**(仅领先 2 个),直接 PR 会触发 `check-common-ancestor` 且带入陈旧基线,故将其 2 个提交 cherry-pick 到基于**当前 `main`** 的新分支后提交,history 干净、可直接合并。

## 改动内容（2 个提交，均 @MaxwellGeng）

- `6f65a219b` **PowerShell (pwsh) native execution + runtime-adaptive terminal description**
- `2db87b711` **Add extra tool check for terminal tool**

| 文件 | 说明 |
|---|---|
| `tools/environments/_find_pwsh.py`(新, 134) | 探测 PATH 上的 pwsh,失败时回退到静默自动安装 |
| `tools/environments/_install_pwsh.py`(新, 368) | Windows 自动安装 PowerShell 7：winget → 官方 GitHub Release MSI(静默 msiexec)→ 便携 ZIP |
| `tools/environments/local.py`(+220) | `_resolve_shell()`：Windows 优先 pwsh、回退 Git Bash;`_run_pwsh()`/`_wrap_command_pwsh()`/`init_session()` 等 pwsh 生命周期;尊重 `HERMES_SHELL_TYPE`(auto/pwsh/bash)、`HERMES_PWSH_PATH` |
| `tools/terminal_tool.py`(+98 / +改) | `_detect_shell_for_description()` + `_build_dynamic_terminal_description()`：按实际 shell 动态替换 LLM 描述里的 `cat/grep/ls/heredoc` 等为 pwsh cmdlet;终端工具额外检查 |
| `model_tools.py`(+9) | 把当前 shell 指纹 `_shell_fp` 加入 `get_tool_definitions()` 缓存键,使 pwsh 自动安装后描述缓存失效 |
| `FORK_NOTES.md` / `.zh-CN.md` | 新增补丁说明(见下方冲突解决) |

## 冲突解决

cherry-pick 时**仅 `FORK_NOTES.md` / `FORK_NOTES.zh-CN.md` 冲突**(代码文件 `local.py`/`terminal_tool.py`/`model_tools.py` 三方合并干净)。原因:`main` 已使用 `P-014`(MCP 打包)/`P-015`(IM 后端),而本功能在旧基线上也编号为 `P-014`,**P 号冲突**。已将本功能**重编号为 `P-016`**(下一个空号),保留 main 的 P-014/P-015。表格 P 号现连续 P-001…P-016。

## 验证

- ✅ `python -m py_compile` 全部改动 .py 通过。
- ✅ cherry-pick 干净(仅文档冲突,已解决);2 个提交均保留 @MaxwellGeng 署名。
- ⚠️ **本环境为 Linux,无法跑 Windows 实测**。pwsh 探测/安装/执行均为 Windows 路径,**合并前需 Windows 真机验证**(pwsh 已装 / 未装两种场景、`HERMES_SHELL_TYPE` 各值)。

## 评审注意事项（建议 reviewer 关注）

1. 🔸 **缺测试**:`FORK_NOTES` 的 P-016 详情声称有 `tests/tools/test_terminal_dynamic_description.py`(14 个用例),但**该文件不在提交中**(原 commit 未包含)。建议补测试或修正文档表述。
2. 🔸 **供应链**:`_install_pwsh.py` 会**静默下载并安装** PowerShell 7。来源为官方 `github.com/PowerShell/PowerShell/releases`(HTTPS),但 MSI **未做 checksum/签名校验**(仅安装后验证 pwsh 可执行)。建议确认是否需要校验下载产物;仓库的 "Scan PR for critical supply chain risks" 检查可能会标记。
3. 🔸 **行为变更**:Windows 上若检测到/装上 pwsh,本地终端命令将从 Git Bash 切到 **pwsh** 执行(`;` 而非 `&&`、`$env:VAR` 等)。`auto` 模式在 pwsh 不可用时回退 bash;可用 `HERMES_SHELL_TYPE=bash` 强制保留旧行为。
4. Docker/SSH/Modal 后端不受影响(始终容器内 bash)。

来源分支:`dev-fix`(@MaxwellGeng)。
