### PR TITLE
[codex] 修复 runtime 打包缺少 typer 依赖

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -144,7 +144,7 @@ jobs:
           missing = []
           for m in ("mcp", "lark_oapi", "dingtalk_stream", "alibabacloud_dingtalk",
                     "alibabacloud_tea_openapi", "alibabacloud_tea_util",
-                    "aiohttp", "qrcode", "defusedxml", "certifi"):
+                    "aiohttp", "qrcode", "defusedxml", "certifi", "typer"):
               try:
                   importlib.import_module(m)
               except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,6 +263,10 @@ cn-desktop = [
   "hermes-agent[web]",        # dashboard: fastapi / uvicorn / starlette
   "hermes-agent[anthropic]",  # native Anthropic transport (MiniMax-CN etc.)
   "hermes-agent[mcp]",        # native MCP client SDK (issue #16)
+  # PyInstaller's --collect-submodules mcp imports mcp.cli during analysis.
+  # The mcp package keeps its CLI deps behind the mcp[cli] extra, so the frozen
+  # runtime build must install typer explicitly or all platform builds fail.
+  "typer==0.24.1",
   "hermes-agent[feishu]",     # 飞书 / Lark — lark-oapi
   "hermes-agent[dingtalk]",   # 钉钉 — dingtalk-stream + alibabacloud SDK
   "hermes-agent[wecom]",      # 企业微信 callback — defusedxml

--- a/uv.lock
+++ b/uv.lock
@@ -1458,6 +1458,7 @@ cn-desktop = [
     { name = "mcp" },
     { name = "qrcode" },
     { name = "starlette" },
+    { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 computer-use = [
@@ -1711,6 +1712,7 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'web'", specifier = "==1.0.1" },
     { name = "tenacity", specifier = "==9.1.4" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.21" },
+    { name = "typer", marker = "extra == 'cn-desktop'", specifier = "==0.24.1" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = "==2025.3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0,<1" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = "==0.41.0" },


### PR DESCRIPTION
## 变更内容

修复 `release-runtime` 在 PyInstaller 扫描 `mcp` 子模块时，因为 `mcp.cli` 缺少 CLI 依赖 `typer` 而导致 macOS、Windows、Linux runtime 构建全部失败的问题。

具体变更：

- 在 `cn-desktop` extra 中显式加入 `typer==0.24.1`。
- 更新 `uv.lock` 中的 `cn-desktop` 依赖元数据。
- 在 runtime 构建预检中加入 `typer` import，确保类似缺失依赖能在 PyInstaller 前暴露。

## 根因

`release-runtime.yml` 新增了 `--collect-submodules mcp` 后，PyInstaller 会在 analysis 阶段导入 `mcp.cli`。`mcp` 包把 CLI 依赖放在 `mcp[cli]` extra 下，当前 `cn-desktop` 只安装了 `mcp==1.26.0`，没有安装 `typer`，所以三个平台都在同一步失败。

## 验证

- `uv lock`
- `git diff --check`
- `uv lock --check`
- 使用 Python 3.11 临时 venv 安装 `.[cn-desktop]` 和 `pyinstaller==6.*`，验证 `mcp`、`typer`、`mcp.cli` 以及 CN 平台后端依赖均可 import，并验证 `PyInstaller.utils.hooks.collect_submodules("mcp")` 能成功收集且包含 `mcp.cli`。