### PR TITLE
[codex] 补齐 runtime 冻结后端依赖元数据

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -183,6 +183,9 @@ jobs:
           # client expects an executable named hermes-agent-cn-runtime-<platform>-<arch>{.ext}.
           # Hidden imports cover modules PyInstaller doesn't discover via
           # static analysis (lazy imports inside hermes_cli/main.py).
+          # The cn-desktop runtime cannot lazy-install packages after freezing,
+          # so collect both the direct backend packages and the cross-platform
+          # transitive SDK packages those backends load dynamically.
           NAME="hermes-agent-cn-runtime-${{ matrix.platform }}-${{ matrix.arch }}"
           pyinstaller --noconfirm \
             --name "$NAME" \
@@ -201,8 +204,25 @@ jobs:
             --collect-submodules alibabacloud_dingtalk \
             --collect-submodules alibabacloud_tea_openapi \
             --collect-submodules alibabacloud_tea_util \
+            --collect-submodules alibabacloud_endpoint_util \
+            --collect-submodules alibabacloud_gateway_dingtalk \
+            --collect-submodules alibabacloud_gateway_spi \
+            --collect-submodules alibabacloud_credentials \
+            --collect-submodules alibabacloud_credentials_api \
+            --collect-submodules alibabacloud_openapi_util \
+            --collect-submodules Tea \
+            --collect-submodules darabonba \
+            --collect-submodules requests_toolbelt \
             --collect-submodules aiohttp \
+            --collect-submodules websockets \
+            --collect-submodules apscheduler \
+            --collect-submodules aiofiles \
             --collect-submodules qrcode \
+            --collect-submodules png \
+            --collect-submodules defusedxml \
+            --collect-submodules cryptography \
+            --collect-submodules certifi \
+            --collect-submodules typer \
             --collect-data hermes_cli \
             --collect-data gateway \
             --collect-data plugins \
@@ -217,9 +237,31 @@ jobs:
             --copy-metadata pydantic \
             --copy-metadata anthropic \
             --copy-metadata mcp \
+            --copy-metadata typer \
             --copy-metadata lark_oapi \
             --copy-metadata dingtalk_stream \
             --copy-metadata alibabacloud_dingtalk \
+            --copy-metadata alibabacloud_tea_openapi \
+            --copy-metadata alibabacloud_tea_util \
+            --copy-metadata alibabacloud_endpoint_util \
+            --copy-metadata alibabacloud_gateway_dingtalk \
+            --copy-metadata alibabacloud_gateway_spi \
+            --copy-metadata alibabacloud_credentials \
+            --copy-metadata alibabacloud_credentials_api \
+            --copy-metadata alibabacloud_openapi_util \
+            --copy-metadata alibabacloud_tea \
+            --copy-metadata darabonba_core \
+            --copy-metadata requests_toolbelt \
+            --copy-metadata aiohttp \
+            --copy-metadata websockets \
+            --copy-metadata apscheduler \
+            --copy-metadata aiofiles \
+            --copy-metadata qrcode \
+            --copy-metadata pypng \
+            --copy-metadata defusedxml \
+            --copy-metadata cryptography \
+            --copy-metadata pycryptodome \
+            --copy-metadata certifi \
             --paths . \
             -p . \
             hermes_cli/main.py
@@ -289,8 +331,14 @@ jobs:
           # shipped. dist-info names are the normalized (underscored) project
           # names: anthropic, mcp, lark-oapi -> lark_oapi, etc.
           fail=0
-          for pkg in anthropic mcp lark_oapi dingtalk_stream alibabacloud_dingtalk \
-                     aiohttp qrcode defusedxml cryptography; do
+          for pkg in anthropic mcp typer lark_oapi dingtalk_stream alibabacloud_dingtalk \
+                     alibabacloud_tea_openapi alibabacloud_tea_util \
+                     alibabacloud_endpoint_util alibabacloud_gateway_dingtalk \
+                     alibabacloud_gateway_spi alibabacloud_credentials \
+                     alibabacloud_credentials_api alibabacloud_openapi_util \
+                     alibabacloud_tea darabonba_core requests_toolbelt \
+                     aiohttp websockets apscheduler aiofiles qrcode pypng \
+                     defusedxml cryptography pycryptodome certifi; do
             if [[ -z "$(find "$internal" -maxdepth 1 -type d -name "${pkg}-*.dist-info" -print -quit)" ]]; then
               echo "::error::Frozen runtime is missing ${pkg} package metadata" >&2
               find "dist/$NAME" -maxdepth 3 -type d -iname "${pkg}*" -print >&2


### PR DESCRIPTION
## 变更内容

这次不是只补 `runtime-v0.16.0-cn.3` 日志里眼前的 `aiohttp` / `defusedxml`，而是重新盘了一遍 `cn-desktop` runtime extra 会预装的后端依赖，并把 PyInstaller 的显式收集范围补齐到：

- CN desktop 直接后端包：`anthropic`、`mcp`、`typer`、`lark_oapi`、`dingtalk_stream`、`aiohttp`、`qrcode`、`defusedxml`、`cryptography`、`certifi`。
- 钉钉/阿里云 SDK 的跨平台传递包：`alibabacloud_*`、`Tea`、`darabonba`、`requests_toolbelt`、`websockets`、`apscheduler`、`aiofiles`、`png` / `pypng`、`pycryptodome`。
- frozen runtime metadata 校验同步扩展，避免后续 release tag 到同一类缺 dist-info 问题才失败。

没有把 `lark_oapi.adapter.flask` 需要的 Flask、Matrix、Telegram、Slack、Mautrix 等 optional 包塞进去，因为它们不是这次 CN desktop runtime 目标后端，PyInstaller 对 Flask adapter 的 warning 是可选适配器路径。

## 根因

`runtime-v0.16.0-cn.3` 已经通过 PyInstaller 构建，失败点推进到了 `Verify frozen runtime backends`，三平台都报 frozen output 缺少 `aiohttp` 和 `defusedxml` package metadata。说明代码包已经能被冻结，但 workflow 的 `--copy-metadata` 仍只覆盖了早期少量 SDK，和扩展后的 `cn-desktop` backend set 不一致。

## 验证

- `git diff --check`
- 本地 Python 3.11 临时环境安装 `.[cn-desktop]` + `pyinstaller==6.*`。
- 本地按扩展后的 PyInstaller 参数冻结 `hermes_cli/main.py` 成 onedir runtime。
- 本地检查以下 dist-info 全部存在：`anthropic`、`mcp`、`typer`、`lark_oapi`、`dingtalk_stream`、`alibabacloud_dingtalk`、`alibabacloud_tea_openapi`、`alibabacloud_tea_util`、`alibabacloud_endpoint_util`、`alibabacloud_gateway_dingtalk`、`alibabacloud_gateway_spi`、`alibabacloud_credentials`、`alibabacloud_credentials_api`、`alibabacloud_openapi_util`、`alibabacloud_tea`、`darabonba_core`、`requests_toolbelt`、`aiohttp`、`websockets`、`apscheduler`、`aiofiles`、`qrcode`、`pypng`、`defusedxml`、`cryptography`、`pycryptodome`、`certifi`。
- 本地冻结二进制通过 `dashboard --help`、`mcp --help`、`mcp serve --help`、`gateway --help` 烟测。