### PR TITLE
[codex] 停止辅助模型默认探测 OpenRouter 和 Nous

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7,20 +7,19 @@ the best available backend without duplicating fallback logic.
 Resolution order for text tasks (auto mode):
   1. User's main provider + main model (used regardless of provider type —
      aggregators, direct API-key providers, native Anthropic, Codex, etc.)
-  2. OpenRouter  (OPENROUTER_API_KEY)
-  3. Nous Portal (~/.hermes/auth.json active provider)
-  4. Custom endpoint (config.yaml model.base_url + OPENAI_API_KEY)
-  5. Native Anthropic
-  6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
-  7. None
+  2. Custom endpoint (config.yaml model.base_url + OPENAI_API_KEY)
+  3. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
+  4. None
+
+OpenRouter and Nous Portal are never probed as implicit text fallbacks. They
+are still used when the user's main provider is OpenRouter/Nous or when a
+caller explicitly requests them via ``auxiliary.<task>.provider``.
 
 Resolution order for vision/multimodal tasks (auto mode):
   1. Selected main provider, if it is one of the supported vision backends below
-  2. OpenRouter
-  3. Nous Portal
-  4. Native Anthropic
-  5. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
-  6. None
+  2. Native Anthropic
+  3. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
+  4. None
 
 Codex OAuth (ChatGPT-account auth) is intentionally NOT in either
 fallback chain: OpenAI gates this endpoint behind an undocumented,
@@ -36,8 +35,8 @@ Default "auto" follows the chains above.
 Payment / credit exhaustion fallback:
   When a resolved provider returns HTTP 402 or a credit-related error,
   call_llm() automatically retries with the next available provider in the
-  auto-detection chain.  This handles the common case where a user depletes
-  their OpenRouter balance but has Codex OAuth or another provider available.
+  auto-detection chain.  Implicit OpenRouter/Nous probing is intentionally
+  excluded; users can still opt into those providers explicitly.
 """
 
 import json
@@ -297,8 +296,8 @@ _PROVIDER_VISION_MODELS: Dict[str, str] = {
 # Providers whose endpoint does not accept image input, even though the
 # provider's broader ecosystem has vision models available elsewhere.  When
 # `auxiliary.vision.provider: auto` sees one of these as the main provider,
-# it must skip straight to the aggregator chain instead of returning a client
-# that will 404 on every vision request.
+# it must skip straight to the dedicated vision fallback chain instead of
+# returning a client that will 404 on every vision request.
 #
 # kimi-coding / kimi-coding-cn: the Kimi Coding Plan routes through
 # api.kimi.com/coding (Anthropic Messages wire) which Kimi's own docs
@@ -1523,7 +1522,6 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
     if pool_present:
         or_key = explicit_api_key or _pool_runtime_api_key(entry)
         if not or_key:
-            _mark_provider_unhealthy("openrouter", ttl=60)
             return None, None
         base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
         logger.debug("Auxiliary client: OpenRouter via pool")
@@ -1532,7 +1530,6 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
 
     or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
     if not or_key:
-        _mark_provider_unhealthy("openrouter", ttl=60)
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
     return OpenAI(api_key=or_key, base_url=OPENROUTER_BASE_URL,
@@ -1564,7 +1561,7 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
                 "Auxiliary: skipping Nous Portal (rate-limited, resets in %.0fs)",
                 _remaining,
             )
-            _mark_provider_unhealthy("nous", ttl=_remaining)
+            _mark_provider_unhealthy("nous", ttl=_remaining, reason="rate limit")
             return None, None
     except Exception:
         pass
@@ -1576,7 +1573,6 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
             "Auxiliary Nous client unavailable: no Nous authentication found "
             "(run: hermes auth)."
         )
-        _mark_provider_unhealthy("nous", ttl=60)
         return None, None
     if runtime is None and nous:
         logger.debug(
@@ -1624,7 +1620,6 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
                 "Auxiliary Nous client unavailable: no usable inference JWT found "
                 "(run: hermes auth add nous)."
             )
-            _mark_provider_unhealthy("nous", ttl=60)
             return None, None
         base_url = str((nous or {}).get("inference_base_url") or _nous_base_url()).rstrip("/")
     return (
@@ -1758,7 +1753,7 @@ def set_runtime_main(
 
     For ``custom:`` providers, ``base_url`` and ``api_key`` must also be
     recorded so that ``_resolve_auto`` can construct a valid client in
-    Step 1 instead of falling through to the aggregator chain.
+    Step 1 instead of falling through to the fallback chain.
     """
     global _RUNTIME_MAIN_PROVIDER, _RUNTIME_MAIN_MODEL
     global _RUNTIME_MAIN_BASE_URL, _RUNTIME_MAIN_API_KEY, _RUNTIME_MAIN_API_MODE
@@ -2200,13 +2195,13 @@ def _get_provider_chain() -> List[tuple]:
     NOTE: ``openai-codex`` is deliberately NOT in this chain.  The
     ChatGPT-account Codex endpoint only accepts a shifting, undocumented
     allow-list of model IDs, so falling back to it with a guessed model
-    fails more often than not.  Codex is used only when the user's main
-    provider *is* openai-codex (see Step 1 of ``_resolve_auto``) or when
-    a caller explicitly requests it with a model.
+    fails more often than not.  OpenRouter and Nous Portal are also
+    excluded from this implicit chain to avoid surprise remote probes.
+    These providers are still used when the user's main provider is one
+    of them (see Step 1 of ``_resolve_auto``) or when a caller explicitly
+    requests them.
     """
     return [
-        ("openrouter", _try_openrouter),
-        ("nous", _try_nous),
         ("local/custom", _try_custom_endpoint),
         ("api-key", _resolve_api_key_provider),
     ]
@@ -2216,10 +2211,10 @@ def _get_provider_chain() -> List[tuple]:
 #
 # When an auxiliary provider returns HTTP 402 (Payment Required / credit
 # exhaustion), retrying it on every subsequent aux call is wasteful — the
-# provider stays depleted for hours or days, but the chain re-tries it as
-# the FIRST entry on every compression/title-gen/session-search call,
-# burns ~1 RTT, gets 402 again, then falls back. On a long Discord/LCM
-# session that adds up to dozens of doomed 402s.
+# provider stays depleted for hours or days. If the provider is the user's
+# main model or an explicit per-task provider, every compression/title-gen
+# call would otherwise burn ~1 RTT, get 402 again, then fall back. On a long
+# Discord/LCM session that adds up to dozens of doomed 402s.
 #
 # Solution: when ANY caller observes a payment error against a provider,
 # mark it unhealthy for ``_AUX_UNHEALTHY_TTL_SECONDS``. ``_resolve_auto``
@@ -2238,7 +2233,9 @@ _aux_unhealthy_logged_at: Dict[str, float] = {}
 
 # Map provider names that show up in resolved_provider / explicit-config
 # back to the chain labels used by _get_provider_chain(). Keep in sync
-# with the alias map in _try_payment_fallback below.
+# with the alias map in _try_payment_fallback below. OpenRouter/Nous labels
+# remain here because they can still be explicit or main providers even though
+# they are no longer implicit auto-fallback rungs.
 _AUX_UNHEALTHY_LABEL_ALIASES = {
     "openrouter": "openrouter",
     "nous": "nous",
@@ -2261,10 +2258,15 @@ def _normalize_chain_label(provider: str) -> str:
     return _AUX_UNHEALTHY_LABEL_ALIASES.get(p, p)
 
 
-def _mark_provider_unhealthy(provider: str, ttl: Optional[float] = None) -> None:
-    """Mark ``provider`` as recently-402'd, hidden from chain iteration
+def _mark_provider_unhealthy(
+    provider: str,
+    ttl: Optional[float] = None,
+    *,
+    reason: str = "payment / credit error",
+) -> None:
+    """Mark ``provider`` as temporarily unhealthy, hidden from chain iteration
     until the TTL expires. Called from the payment-fallback branches in
-    ``call_llm`` and ``acall_llm`` after a confirmed payment error.
+    ``call_llm`` and ``acall_llm`` after a confirmed capacity error.
     """
     label = _normalize_chain_label(provider)
     if not label:
@@ -2272,10 +2274,11 @@ def _mark_provider_unhealthy(provider: str, ttl: Optional[float] = None) -> None
     expires_at = time.time() + (ttl if ttl is not None else _AUX_UNHEALTHY_TTL_SECONDS)
     _aux_unhealthy_until[label] = expires_at
     logger.warning(
-        "Auxiliary: marking %s unhealthy for %ds (payment / credit error). "
+        "Auxiliary: marking %s unhealthy for %ds (%s). "
         "Subsequent auxiliary calls will skip it until %s.",
         label,
         int(ttl if ttl is not None else _AUX_UNHEALTHY_TTL_SECONDS),
+        reason,
         time.strftime("%H:%M:%S", time.localtime(expires_at)),
     )
 
@@ -3086,8 +3089,10 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
          on DeepSeek/ZAI/Alibaba get theirs; etc.  Running aux tasks on the
          user's picked model keeps behavior predictable — no surprise
          switches to a cheap fallback model for side tasks.
-      2. OpenRouter → Nous → custom → Codex → API-key providers (fallback
-         chain, only used when the main provider has no working client).
+      2. Local/custom endpoint → direct API-key providers (fallback chain,
+         only used when the main provider has no working client). OpenRouter
+         and Nous Portal are not implicitly probed here; explicit main or
+         per-task selections still use them.
     """
     global auxiliary_is_nous, _stale_base_url_warned
     auxiliary_is_nous = False  # Reset — _try_nous() will set True if it wins
@@ -3173,7 +3178,7 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
                             main_provider, resolved or main_model)
                 return client, resolved or main_model
 
-    # ── Step 2: aggregator / fallback chain ──────────────────────────────
+    # ── Step 2: local/direct fallback chain ──────────────────────────────
     tried = []
     for label, try_fn in _get_provider_chain():
         if _is_provider_unhealthy(label):
@@ -3191,7 +3196,7 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
         tried.append(label)
     logger.warning("Auxiliary auto-detect: no provider available (tried: %s). "
                    "Compression, summarization, and memory flush will not work. "
-                   "Set OPENROUTER_API_KEY or configure a local model in config.yaml.",
+                   "Configure a local model or an explicit auxiliary provider in config.yaml.",
                    ", ".join(tried))
     return None, None
 
@@ -3973,9 +3978,13 @@ def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Di
     )
 
 
-_VISION_AUTO_PROVIDER_ORDER = (
+_VISION_EXPLICIT_PROVIDER_ORDER = (
     "openrouter",
     "nous",
+    "anthropic",
+)
+
+_VISION_AUTO_PROVIDER_ORDER = (
     "anthropic",
 )
 
@@ -4072,9 +4081,10 @@ def _strict_vision_backend_available(provider: str) -> bool:
 def get_available_vision_backends() -> List[str]:
     """Return the currently available vision backends in auto-selection order.
 
-    Order: active provider → OpenRouter → Nous → Anthropic → stop.  This is the single
-    source of truth for setup, tool gating, and runtime auto-routing of
-    vision tasks.
+    Order: active provider → Anthropic → stop. OpenRouter and Nous are
+    included only when they are the active provider or an explicit vision
+    override. This is the single source of truth for setup, tool gating, and
+    runtime auto-routing of vision tasks.
     """
     available: List[str] = []
     # 1. Active provider — if the user configured a provider, try it first.
@@ -4087,14 +4097,14 @@ def get_available_vision_backends() -> List[str]:
         vision_model = _PROVIDER_VISION_MODELS.get(main_provider, _read_main_model())
         if not _main_model_supports_vision(main_provider, vision_model):
             main_provider = ""
-        elif main_provider in _VISION_AUTO_PROVIDER_ORDER:
+        elif main_provider in _VISION_EXPLICIT_PROVIDER_ORDER:
             if _strict_vision_backend_available(main_provider):
                 available.append(main_provider)
         else:
             client, _ = resolve_provider_client(main_provider, vision_model)
             if client is not None:
                 available.append(main_provider)
-    # 2. OpenRouter, 3. Nous — skip if already covered by main provider.
+    # Auto fallbacks — skip if already covered by main provider.
     for p in _VISION_AUTO_PROVIDER_ORDER:
         if p not in available and _strict_vision_backend_available(p):
             available.append(p)
@@ -4155,10 +4165,12 @@ def resolve_vision_provider_client(
         #      zai → glm-5v-turbo). Nous is the exception: it has a dedicated
         #      strict vision backend with tier-aware defaults, so it must not
         #      fall through to the user's text chat model here.
-        #   2. OpenRouter  (vision-capable aggregator fallback)
-        #   3. Nous Portal (vision-capable aggregator fallback)
-        #   4. Anthropic   (native vision fallback when configured)
-        #   5. Stop
+        #   2. Anthropic   (native vision fallback when configured)
+        #   3. Stop
+        #
+        # OpenRouter and Nous Portal are intentionally not probed as implicit
+        # fallbacks. They are still used when they are the main provider or an
+        # explicit auxiliary.vision.provider override.
         main_provider = _read_main_provider()
         main_model = _read_main_model()
         main_provider_skipped_for_vision = False
@@ -4180,7 +4192,7 @@ def resolve_vision_provider_client(
                 # model does not support image input, switch to a model with
                 # image_in capability" and vision lives on the separate Kimi
                 # Platform (api.moonshot.ai). Skip the main provider and fall
-                # through to the aggregator chain instead of returning a
+                # through to the vision fallback chain instead of returning a
                 # client that will 404 on every vision request (#17076).
                 logger.debug(
                     "Vision auto-detect: skipping main provider %s (no "
@@ -4194,11 +4206,26 @@ def resolve_vision_provider_client(
                 # an image would produce a cryptic provider-side error like
                 # ``unknown variant `image_url`, expected `text``` (#31179).
                 # Fall through to the dedicated vision backend chain instead.
+                # If the user explicitly selected a provider that has its own
+                # strict vision backend (OpenRouter/Nous/Anthropic), use that
+                # provider's vision default rather than probing unrelated
+                # remote aggregators.
                 #
                 # Only log the provider name (not the model) — mirrors the
                 # sibling _PROVIDERS_WITHOUT_VISION branch above, and avoids
                 # CodeQL py/clear-text-logging-sensitive-data heuristic false
                 # positives on multi-value interpolations.
+                if main_provider in _VISION_EXPLICIT_PROVIDER_ORDER:
+                    sync_client, default_model = _resolve_strict_vision_backend(
+                        main_provider
+                    )
+                    if sync_client is not None:
+                        logger.info(
+                            "Vision auto-detect: using main provider %s vision backend (%s)",
+                            main_provider,
+                            default_model or resolved_model or vision_model,
+                        )
+                        return _finalize(main_provider, sync_client, default_model)
                 logger.debug(
                     "Vision auto-detect: skipping main provider %s "
                     "(reports no vision capability) — falling through to "
@@ -4231,7 +4258,7 @@ def resolve_vision_provider_client(
         logger.debug("Auxiliary vision client: none available")
         return None, None, None
 
-    if requested in _VISION_AUTO_PROVIDER_ORDER:
+    if requested in _VISION_EXPLICIT_PROVIDER_ORDER:
         sync_client, default_model = _resolve_strict_vision_backend(
             requested, resolved_model
         )
@@ -5373,8 +5400,8 @@ def call_llm(
         # ── Payment / credit exhaustion fallback ──────────────────────
         # When the resolved provider returns 402 or a credit-related error,
         # try alternative providers instead of giving up.  This handles the
-        # common case where a user runs out of OpenRouter credits but has
-        # Codex OAuth or another provider available.
+        # common case where a user runs out of credits on their explicit/main
+        # auxiliary provider but has another configured backend available.
         #
         # ── Connection error fallback ────────────────────────────────
         # When a provider endpoint is unreachable (DNS failure, connection

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1192,8 +1192,10 @@ DEFAULT_CONFIG = {
     # Format: provider is the provider name, model is the model slug.
     # "auto" for provider = auto-detect best available provider.
     # Empty model = use provider's default auxiliary model.
-    # All tasks fall back to openrouter:google/gemini-3-flash-preview if
-    # the configured provider is unavailable.
+    # "auto" uses the main chat model first, then local/custom endpoints and
+    # directly configured API-key providers. OpenRouter and Nous Portal are
+    # used only when selected as the main model provider or explicitly assigned
+    # to an auxiliary task.
     #
     # extra_body: forwarded verbatim as request body fields on every aux call
     # for that task. Use this to set provider-specific knobs (independent of

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3046,9 +3046,9 @@ def _aux_config_menu() -> None:
         print()
         print("  Side tasks (vision, compression, web extraction, etc.) default")
         print('  to your main chat model.  "auto" means "use my main model" —')
-        print("  Hermes only falls back to a lightweight backend (OpenRouter,")
-        print("  Nous Portal) if the main model is unavailable.  Override a")
-        print("  task below if you want it pinned to a specific provider/model.")
+        print("  then local/custom endpoints and directly configured API-key")
+        print("  providers if the main model is unavailable.  Override a task")
+        print("  below if you want it pinned to a specific provider/model.")
         print()
 
         # Build the task menu with current settings inline

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -511,8 +511,7 @@ class TestResolveProviderClientUniversalModelFallback:
     ``(None, None)`` on an empty model — both lack a catalog default
     because their accepted-model lists drift on the backend.  That
     silent failure caused ``_resolve_auto`` to drop to its Step-2
-    fallback chain (OpenRouter / Nous / etc.), so aux tasks billed
-    against the wrong subscription.
+    fallback chain, so aux tasks billed against the wrong subscription.
     """
 
     def test_empty_model_for_oauth_provider_falls_back_to_main_model(self):
@@ -608,7 +607,7 @@ class TestResolveProviderClientUniversalModelFallback:
             client, model = resolve_provider_client("anthropic", "")
 
         # Catalog default takes precedence — main_model was a no-op
-        # because step 2 of the fallback chain already produced a model.
+        # because the provider's own catalog default already produced a model.
         assert client is not None
         assert model == "claude-haiku-4-5-20251001"
         mock_read_main.assert_not_called()
@@ -678,21 +677,10 @@ class TestExpiredCodexFallback:
             assert not isinstance(client, type(None)), "Should find a provider after expired Codex"
 
 
-    def test_expired_codex_openrouter_wins(self, tmp_path, monkeypatch):
-        """With expired Codex + OpenRouter key, OpenRouter should win (1st in chain)."""
+    def test_expired_codex_openrouter_key_is_not_implicit_fallback(self, tmp_path, monkeypatch):
+        """OpenRouter key alone should not make auto probe OpenRouter implicitly."""
         import base64
         import time as _time
-
-        # Belt-and-suspenders: _try_openrouter marks openrouter unhealthy
-        # when OPENROUTER_API_KEY is absent (which the preceding test in
-        # this class exercises).  The file-level _clean_env autouse fixture
-        # clears the cache, but fixture ordering with the conftest
-        # _hermetic_environment autouse can leave a narrow window where
-        # the mark reappears.  Explicitly clear here so this test is
-        # independent of run order.
-        import agent.auxiliary_client as _aux_mod
-        _aux_mod._aux_unhealthy_until.clear()
-        _aux_mod._aux_unhealthy_logged_at.clear()
 
         header = base64.urlsafe_b64encode(b'{"alg":"RS256","typ":"JWT"}').rstrip(b"=").decode()
         payload_data = json.dumps({"exp": int(_time.time()) - 3600}).encode()
@@ -712,13 +700,16 @@ class TestExpiredCodexFallback:
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
 
-        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
-            mock_openai.return_value = MagicMock()
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai, \
+             patch("agent.auxiliary_client._try_openrouter") as or_try, \
+             patch("agent.auxiliary_client._try_nous") as nous_try:
             from agent.auxiliary_client import _resolve_auto
             client, model = _resolve_auto()
-            assert client is not None
-            # OpenRouter is 1st in chain, should win
-            mock_openai.assert_called()
+        assert client is None
+        assert model is None
+        mock_openai.assert_not_called()
+        or_try.assert_not_called()
+        nous_try.assert_not_called()
 
     def test_expired_codex_custom_endpoint_wins(self, tmp_path, monkeypatch):
         """With expired Codex + custom endpoint (Ollama), custom should win (3rd in chain)."""
@@ -836,6 +827,8 @@ class TestExplicitProviderRouting:
             assert adapter._is_oauth is False
 
     def test_explicit_openrouter_pool_exhausted_logs_precise_warning(self, monkeypatch, caplog):
+        from agent.auxiliary_client import _is_provider_unhealthy
+
         monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
         with patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)):
             with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
@@ -850,8 +843,11 @@ class TestExplicitProviderRouting:
             "OPENROUTER_API_KEY not set" in record.message
             for record in caplog.records
         )
+        assert _is_provider_unhealthy("openrouter") is False
 
     def test_explicit_openrouter_missing_env_keeps_not_set_warning(self, monkeypatch, caplog):
+        from agent.auxiliary_client import _is_provider_unhealthy
+
         monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
         with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
             with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
@@ -862,6 +858,8 @@ class TestExplicitProviderRouting:
             "OPENROUTER_API_KEY not set" in record.message
             for record in caplog.records
         )
+        assert not any("marking openrouter unhealthy" in record.message for record in caplog.records)
+        assert _is_provider_unhealthy("openrouter") is False
 
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""
@@ -896,12 +894,15 @@ class TestGetTextAuxiliaryClient:
         monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-        with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
-             patch("agent.auxiliary_client._read_codex_access_token", return_value=None), \
+        with patch("agent.auxiliary_client._try_openrouter") as or_try, \
+             patch("agent.auxiliary_client._try_nous") as nous_try, \
+             patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
              patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)):
             client, model = get_text_auxiliary_client()
         assert client is None
         assert model is None
+        or_try.assert_not_called()
+        nous_try.assert_not_called()
 
     def test_custom_endpoint_uses_codex_wrapper_when_runtime_requests_responses_api(self):
         with patch("agent.auxiliary_client._resolve_custom_runtime",
@@ -951,6 +952,21 @@ class TestVisionClientFallback:
 
 
 class TestAuxiliaryPoolAwareness:
+    def test_try_nous_missing_auth_does_not_mark_unhealthy(self, caplog):
+        from agent.auxiliary_client import _is_provider_unhealthy, _try_nous
+
+        with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.auxiliary_client._resolve_nous_runtime_api", return_value=None), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+                client, model = _try_nous()
+
+        assert client is None
+        assert model is None
+        assert any("no Nous authentication found" in record.message for record in caplog.records)
+        assert not any("marking nous unhealthy" in record.message for record in caplog.records)
+        assert _is_provider_unhealthy("nous") is False
+
     def test_try_nous_uses_pool_entry(self):
         pooled_token = _jwt_with_claims({
             "scope": "inference:invoke",
@@ -1464,11 +1480,15 @@ class TestIsRateLimitError:
 class TestGetProviderChain:
     """_get_provider_chain() resolves functions at call time (testable)."""
 
-    def test_returns_four_entries(self):
+    def test_returns_local_and_direct_api_entries_only(self):
         chain = _get_provider_chain()
-        assert len(chain) == 4
+        assert len(chain) == 2
         labels = [label for label, _ in chain]
-        assert labels == ["openrouter", "nous", "local/custom", "api-key"]
+        assert labels == ["local/custom", "api-key"]
+        # OpenRouter/Nous are deliberately not implicit fallback rungs. They
+        # still work when selected as the main provider or an explicit aux task.
+        assert "openrouter" not in labels
+        assert "nous" not in labels
         # Codex is deliberately NOT in this chain — see _get_provider_chain
         # docstring. ChatGPT-account Codex has a shifting model allow-list;
         # guessing a model to fall back on breaks more often than it helps.
@@ -1477,9 +1497,9 @@ class TestGetProviderChain:
     def test_picks_up_patched_functions(self):
         """Patches on _try_* functions must be visible in the chain."""
         sentinel = lambda: ("patched", "model")
-        with patch("agent.auxiliary_client._try_openrouter", sentinel):
+        with patch("agent.auxiliary_client._try_custom_endpoint", sentinel):
             chain = _get_provider_chain()
-        assert chain[0] == ("openrouter", sentinel)
+        assert chain[0] == ("local/custom", sentinel)
 
 
 class TestTryPaymentFallback:
@@ -1501,42 +1521,39 @@ class TestTryPaymentFallback:
 
     def test_skips_failed_provider(self):
         mock_client = MagicMock()
-        with patch("agent.auxiliary_client._try_openrouter", return_value=(None, None)), \
-             patch("agent.auxiliary_client._try_nous", return_value=(mock_client, "nous-model")), \
-             patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"):
-            client, model, label = _try_payment_fallback("openrouter", task="compression")
+        with patch("agent.auxiliary_client._try_custom_endpoint") as custom_try, \
+             patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(mock_client, "api-model")), \
+             patch("agent.auxiliary_client._read_main_provider", return_value="custom"):
+            client, model, label = _try_payment_fallback("local/custom", task="compression")
         assert client is mock_client
-        assert model == "nous-model"
-        assert label == "nous"
+        assert model == "api-model"
+        assert label == "api-key"
+        custom_try.assert_not_called()
 
     def test_returns_none_when_no_fallback(self):
-        with patch("agent.auxiliary_client._try_openrouter", return_value=(None, None)), \
-             patch("agent.auxiliary_client._try_nous", return_value=(None, None)), \
-             patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
+        with patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
              patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)), \
              patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"):
             client, model, label = _try_payment_fallback("openrouter")
         assert client is None
         assert label == ""
 
-    def test_codex_alias_maps_to_chain_label(self):
-        """'codex' should map to 'openai-codex' in the skip set."""
+    def test_codex_alias_does_not_add_codex_fallback(self):
+        """'codex' normalizes for skip logic but is never added as a fallback rung."""
         mock_client = MagicMock()
-        with patch("agent.auxiliary_client._try_openrouter", return_value=(mock_client, "or-model")), \
+        with patch("agent.auxiliary_client._try_custom_endpoint", return_value=(mock_client, "local-model")), \
              patch("agent.auxiliary_client._read_main_provider", return_value="openai-codex"):
             client, model, label = _try_payment_fallback("openai-codex", task="vision")
         assert client is mock_client
-        assert label == "openrouter"
+        assert label == "local/custom"
 
     def test_codex_not_in_fallback_chain(self):
         """Codex is deliberately NOT a fallback rung (shifting model allow-list).
 
-        When OR/Nous/custom/api-key all fail, payment-fallback returns None —
+        When custom/api-key fail, payment-fallback returns None —
         Codex is never tried with a guessed model.
         """
-        with patch("agent.auxiliary_client._try_openrouter", return_value=(None, None)), \
-             patch("agent.auxiliary_client._try_nous", return_value=(None, None)), \
-             patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
+        with patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
              patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)), \
              patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"):
             client, model, label = _try_payment_fallback("openrouter")
@@ -2709,13 +2726,13 @@ class TestCodexAdapterReasoningTranslation:
 class TestVisionAutoSkipsKimiCoding:
     """_resolve_auto vision branch skips providers that have no vision on
     their main endpoint (e.g. Kimi Coding Plan /coding) and falls through
-    to the aggregator chain instead of handing back a client that will 404
-    on every request (#17076).
+    to the configured vision fallback chain instead of handing back a client
+    that will 404 on every request (#17076).
     """
 
-    def test_kimi_coding_skipped_falls_through_to_openrouter(self, monkeypatch):
-        """kimi-coding as main + vision auto → OpenRouter (not kimi)."""
-        fake_or_client = MagicMock(name="openrouter_client")
+    def test_kimi_coding_skipped_falls_through_to_anthropic(self, monkeypatch):
+        """kimi-coding as main + vision auto → Anthropic (not Kimi or aggregators)."""
+        fake_vision_client = MagicMock(name="anthropic_client")
 
         monkeypatch.setattr(
             "agent.auxiliary_client._read_main_provider", lambda: "kimi-coding",
@@ -2734,10 +2751,8 @@ class TestVisionAutoSkipsKimiCoding:
         )
 
         def fake_strict(provider, model=None):
-            if provider == "openrouter":
-                return fake_or_client, "google/gemini-3-flash-preview"
-            if provider == "nous":
-                return None, None
+            if provider == "anthropic":
+                return fake_vision_client, "claude-haiku-4-5-20251001"
             raise AssertionError(
                 f"strict vision backend should not be called for {provider!r} "
                 "when main provider is kimi-coding"
@@ -2748,13 +2763,13 @@ class TestVisionAutoSkipsKimiCoding:
         )
 
         provider, client, model = resolve_vision_provider_client()
-        assert provider == "openrouter"
-        assert client is fake_or_client
-        assert model == "google/gemini-3-flash-preview"
+        assert provider == "anthropic"
+        assert client is fake_vision_client
+        assert model == "claude-haiku-4-5-20251001"
 
     def test_kimi_coding_cn_skipped_too(self, monkeypatch):
         """Same skip applies to the CN variant."""
-        fake_or_client = MagicMock(name="openrouter_client")
+        fake_vision_client = MagicMock(name="anthropic_client")
 
         monkeypatch.setattr(
             "agent.auxiliary_client._read_main_provider", lambda: "kimi-coding-cn",
@@ -2769,18 +2784,18 @@ class TestVisionAutoSkipsKimiCoding:
         )
         monkeypatch.setattr(
             "agent.auxiliary_client._resolve_strict_vision_backend",
-            lambda p, m=None: (fake_or_client, "gemini")
-            if p == "openrouter"
+            lambda p, m=None: (fake_vision_client, "claude-haiku")
+            if p == "anthropic"
             else (None, None),
         )
 
         provider, client, _ = resolve_vision_provider_client()
-        assert provider == "openrouter"
-        assert client is fake_or_client
+        assert provider == "anthropic"
+        assert client is fake_vision_client
 
     def test_minimax_cn_skipped_too(self, monkeypatch):
         """MiniMax M2.x is text-only on the current Anthropic-compatible endpoint."""
-        fake_or_client = MagicMock(name="openrouter_client")
+        fake_vision_client = MagicMock(name="anthropic_client")
 
         monkeypatch.setattr(
             "agent.auxiliary_client._read_main_provider", lambda: "minimax-cn",
@@ -2796,17 +2811,17 @@ class TestVisionAutoSkipsKimiCoding:
         )
         monkeypatch.setattr(
             "agent.auxiliary_client._resolve_strict_vision_backend",
-            lambda p, m=None: (fake_or_client, "gemini")
-            if p == "openrouter"
+            lambda p, m=None: (fake_vision_client, "claude-haiku")
+            if p == "anthropic"
             else (None, None),
         )
 
         provider, client, _ = resolve_vision_provider_client()
-        assert provider == "openrouter"
-        assert client is fake_or_client
+        assert provider == "anthropic"
+        assert client is fake_vision_client
 
     def test_minimax_cn_can_fall_through_to_anthropic(self, monkeypatch):
-        """If aggregator vision is unavailable, MiniMax auto mode can use Anthropic."""
+        """MiniMax auto mode can use the remaining dedicated Anthropic fallback."""
         fake_anthropic_client = MagicMock(name="anthropic_client")
 
         monkeypatch.setattr(
@@ -2822,8 +2837,6 @@ class TestVisionAutoSkipsKimiCoding:
         )
 
         def fake_strict(provider, model=None):
-            if provider in {"openrouter", "nous"}:
-                return None, None
             if provider == "anthropic":
                 return fake_anthropic_client, "claude-haiku-4-5-20251001"
             raise AssertionError(f"unexpected vision backend {provider!r}")
@@ -2860,7 +2873,7 @@ class TestVisionAutoSkipsKimiCoding:
 
     def test_text_only_main_model_capability_skips_generic_provider(self, monkeypatch):
         """Known text-only models must not be used as auto vision backends."""
-        fake_or_client = MagicMock(name="openrouter_client")
+        fake_vision_client = MagicMock(name="anthropic_client")
 
         monkeypatch.setattr(
             "agent.auxiliary_client._read_main_provider", lambda: "deepseek",
@@ -2879,15 +2892,15 @@ class TestVisionAutoSkipsKimiCoding:
         )
         monkeypatch.setattr(
             "agent.auxiliary_client._resolve_strict_vision_backend",
-            lambda p, m=None: (fake_or_client, "google/gemini-3-flash-preview")
-            if p == "openrouter"
+            lambda p, m=None: (fake_vision_client, "claude-haiku")
+            if p == "anthropic"
             else (None, None),
         )
 
         provider, client, model = resolve_vision_provider_client()
-        assert provider == "openrouter"
-        assert client is fake_or_client
-        assert model == "google/gemini-3-flash-preview"
+        assert provider == "anthropic"
+        assert client is fake_vision_client
+        assert model == "claude-haiku"
 
     def test_text_only_openrouter_main_model_uses_openrouter_vision_default(self, monkeypatch):
         """OpenRouter as main provider should fall back to its vision default model."""
@@ -3634,20 +3647,18 @@ class TestAuxUnhealthyCache:
             _resolve_auto,
             _mark_provider_unhealthy,
         )
-        nous_client = MagicMock()
-        # Mark OpenRouter unhealthy → chain should skip it and pick nous.
-        _mark_provider_unhealthy("openrouter")
+        api_client = MagicMock()
+        # Mark local/custom unhealthy → chain should skip it and pick api-key.
+        _mark_provider_unhealthy("local/custom")
         with patch("agent.auxiliary_client._read_main_provider", return_value=""), \
              patch("agent.auxiliary_client._read_main_model", return_value=""), \
-             patch("agent.auxiliary_client._try_openrouter") as or_try, \
-             patch("agent.auxiliary_client._try_nous", return_value=(nous_client, "nous-model")), \
-             patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
-             patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)):
+             patch("agent.auxiliary_client._try_custom_endpoint") as custom_try, \
+             patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(api_client, "api-model")):
             client, model = _resolve_auto()
-        assert client is nous_client
-        assert model == "nous-model"
+        assert client is api_client
+        assert model == "api-model"
         # The skipped provider's _try_* should NOT have been called at all.
-        or_try.assert_not_called()
+        custom_try.assert_not_called()
 
     def test_resolve_auto_skips_unhealthy_main_in_step1(self):
         """Step-1 also consults the unhealthy cache so a depleted main
@@ -3657,21 +3668,23 @@ class TestAuxUnhealthyCache:
             _resolve_auto,
             _mark_provider_unhealthy,
         )
-        nous_client = MagicMock()
+        local_client = MagicMock()
         _mark_provider_unhealthy("openrouter")
         with patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"), \
              patch("agent.auxiliary_client._read_main_model", return_value="anthropic/claude-sonnet-4.6"), \
              patch("agent.auxiliary_client.resolve_provider_client") as step1, \
              patch("agent.auxiliary_client._try_openrouter") as or_try, \
-             patch("agent.auxiliary_client._try_nous", return_value=(nous_client, "n-model")), \
-             patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
+             patch("agent.auxiliary_client._try_nous") as nous_try, \
+             patch("agent.auxiliary_client._try_custom_endpoint", return_value=(local_client, "local-model")), \
              patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)):
             client, model = _resolve_auto()
         # Step-1 was bypassed — resolve_provider_client never invoked
         step1.assert_not_called()
-        # Step-2 also skipped openrouter and landed on nous
+        # Step-2 no longer probes OpenRouter/Nous implicitly and lands on local/custom.
         or_try.assert_not_called()
-        assert client is nous_client
+        nous_try.assert_not_called()
+        assert client is local_client
+        assert model == "local-model"
 
     def test_payment_fallback_skips_unhealthy(self):
         """_try_payment_fallback also consults the unhealthy cache so a 402
@@ -3681,20 +3694,20 @@ class TestAuxUnhealthyCache:
             _try_payment_fallback,
             _mark_provider_unhealthy,
         )
-        nous_client = MagicMock()
-        # Mark BOTH the failed provider (openrouter) and a sibling (custom)
-        # unhealthy. The chain should still find nous.
+        api_client = MagicMock()
+        # Mark a sibling (custom) unhealthy. The chain should still find api-key.
         _mark_provider_unhealthy("local/custom")
         with patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"), \
              patch("agent.auxiliary_client._try_openrouter") as or_try, \
-             patch("agent.auxiliary_client._try_nous", return_value=(nous_client, "n-model")), \
+             patch("agent.auxiliary_client._try_nous") as nous_try, \
              patch("agent.auxiliary_client._try_custom_endpoint") as custom_try, \
-             patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)):
+             patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(api_client, "api-model")):
             client, model, label = _try_payment_fallback("openrouter", task="compression")
-        assert client is nous_client
-        assert label == "nous"
-        # OR is skipped via skip_chain_labels (failed provider), custom via unhealthy cache.
+        assert client is api_client
+        assert label == "api-key"
+        # OR/Nous are no longer implicit rungs; custom is skipped via unhealthy cache.
         or_try.assert_not_called()
+        nous_try.assert_not_called()
         custom_try.assert_not_called()
 
     def test_call_llm_marks_provider_unhealthy_on_402(self, monkeypatch):

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -7,8 +7,9 @@ and surprising — users picked Claude but got Gemini Flash summaries.
 
 The current policy: ``auto`` means "use my main chat model" for every user,
 regardless of provider type.  Explicit per-task overrides in ``config.yaml``
-(``auxiliary.<task>.provider``) still win.  The cheap fallback chain only
-runs when the main provider has no working client.
+(``auxiliary.<task>.provider``) still win.  The fallback chain only uses
+local/custom endpoints and directly configured API-key providers when the
+main provider has no working client.
 """
 
 from __future__ import annotations
@@ -53,7 +54,6 @@ class TestResolveAutoMainFirst:
 
     def test_nous_main_uses_main_model_for_aux(self, monkeypatch):
         """Nous Portal main user → aux uses their picked Nous model, not free-tier MiMo."""
-        # No OPENROUTER_API_KEY → ensures if main failed we'd fall to chain
         with patch(
             "agent.auxiliary_client._read_main_provider", return_value="nous",
         ), patch(
@@ -97,8 +97,6 @@ class TestResolveAutoMainFirst:
 
     def test_main_unavailable_falls_through_to_chain(self, monkeypatch):
         """Main provider with no working client → fall back to aux chain."""
-        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
-
         chain_client = MagicMock()
         with patch(
             "agent.auxiliary_client._read_main_provider", return_value="anthropic",
@@ -108,15 +106,21 @@ class TestResolveAutoMainFirst:
             "agent.auxiliary_client.resolve_provider_client",
             return_value=(None, None),  # main provider has no client
         ), patch(
+            "agent.auxiliary_client._try_custom_endpoint",
+            return_value=(chain_client, "local-model"),
+        ), patch(
             "agent.auxiliary_client._try_openrouter",
-            return_value=(chain_client, "google/gemini-3-flash-preview"),
-        ):
+        ) as or_try, patch(
+            "agent.auxiliary_client._try_nous",
+        ) as nous_try:
             from agent.auxiliary_client import _resolve_auto
 
             client, model = _resolve_auto()
 
         assert client is chain_client
-        assert model == "google/gemini-3-flash-preview"
+        assert model == "local-model"
+        or_try.assert_not_called()
+        nous_try.assert_not_called()
 
     def test_no_main_config_uses_chain_directly(self):
         """No main provider configured → skip step 1, use chain (no regression)."""
@@ -126,14 +130,21 @@ class TestResolveAutoMainFirst:
         ), patch(
             "agent.auxiliary_client._read_main_model", return_value="",
         ), patch(
+            "agent.auxiliary_client._try_custom_endpoint",
+            return_value=(chain_client, "local-model"),
+        ), patch(
             "agent.auxiliary_client._try_openrouter",
-            return_value=(chain_client, "google/gemini-3-flash-preview"),
-        ):
+        ) as or_try, patch(
+            "agent.auxiliary_client._try_nous",
+        ) as nous_try:
             from agent.auxiliary_client import _resolve_auto
 
             client, model = _resolve_auto()
 
         assert client is chain_client
+        assert model == "local-model"
+        or_try.assert_not_called()
+        nous_try.assert_not_called()
 
     def test_runtime_override_wins_over_config(self, monkeypatch):
         """main_runtime kwarg overrides config-read main provider/model."""
@@ -348,9 +359,14 @@ class TestResolveVisionMainFirst:
         assert captured == {"is_agent_turn": True, "is_vision": False}
         assert "default_headers" not in mock_openai.call_args.kwargs
 
-    def test_main_unavailable_vision_falls_through_to_aggregators(self):
-        """Main provider fails → fall back to OpenRouter/Nous strict backends."""
+    def test_main_unavailable_vision_falls_through_to_anthropic(self):
+        """Main provider fails → fall back to the remaining strict vision backend."""
         fallback_client = MagicMock()
+
+        def fake_strict(provider, model=None):
+            assert provider == "anthropic"
+            return fallback_client, "claude-haiku-4-5-20251001"
+
         with patch(
             "agent.auxiliary_client._read_main_provider", return_value="deepseek",
         ), patch(
@@ -360,7 +376,7 @@ class TestResolveVisionMainFirst:
             return_value=(None, None),
         ), patch(
             "agent.auxiliary_client._resolve_strict_vision_backend",
-            return_value=(fallback_client, "google/gemini-3-flash-preview"),
+            side_effect=fake_strict,
         ), patch(
             "agent.auxiliary_client._resolve_task_provider_model",
             return_value=("auto", None, None, None, None),
@@ -370,7 +386,8 @@ class TestResolveVisionMainFirst:
             provider, client, model = resolve_vision_provider_client()
 
         assert client is fallback_client
-        assert provider in {"openrouter", "nous"}
+        assert provider == "anthropic"
+        assert model == "claude-haiku-4-5-20251001"
 
     def test_explicit_provider_override_still_wins(self):
         """Explicit config override bypasses main-first policy."""

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -1011,26 +1011,46 @@ class TestBuildAssistantMessage:
 class TestAuxiliaryClientProviderPriority:
     """Verify auxiliary client resolution doesn't break for any provider."""
 
-    def test_openrouter_always_wins(self, monkeypatch):
+    def test_openrouter_key_is_not_implicit_fallback(self, monkeypatch):
+        """OpenRouter key alone should not make auto probe OpenRouter."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from agent.auxiliary_client import get_text_auxiliary_client
-        with patch("agent.auxiliary_client.OpenAI") as mock:
+        with patch("agent.auxiliary_client._read_main_provider", return_value=""), \
+             patch("agent.auxiliary_client._read_main_model", return_value=""), \
+             patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
+             patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)), \
+             patch("agent.auxiliary_client._try_openrouter") as try_openrouter, \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
             client, model = get_text_auxiliary_client()
-        assert model == "google/gemini-3-flash-preview"
-        assert "openrouter" in str(mock.call_args.kwargs["base_url"]).lower()
+        assert client is None
+        assert model is None
+        try_openrouter.assert_not_called()
+        mock_openai.assert_not_called()
 
-    def test_nous_when_no_openrouter(self, monkeypatch):
+    def test_nous_auth_is_not_implicit_fallback(self, monkeypatch):
+        """Nous auth alone should not make auto probe Nous Portal."""
         monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from agent.auxiliary_client import get_text_auxiliary_client
         nous_auth = {
             "access_token": _fake_invoke_jwt(),
             "scope": "inference:invoke",
         }
-        with patch("agent.auxiliary_client._read_nous_auth", return_value=nous_auth), \
-             patch("agent.auxiliary_client.OpenAI") as mock, \
+        with patch("agent.auxiliary_client._read_main_provider", return_value=""), \
+             patch("agent.auxiliary_client._read_main_model", return_value=""), \
+             patch("agent.auxiliary_client._read_nous_auth", return_value=nous_auth) as read_nous_auth, \
+             patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
+             patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)), \
+             patch("agent.auxiliary_client._try_nous") as try_nous, \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai, \
              patch("hermes_cli.models.get_nous_recommended_aux_model", return_value=None):
             client, model = get_text_auxiliary_client()
-        assert model == "google/gemini-3-flash-preview"
+        assert client is None
+        assert model is None
+        read_nous_auth.assert_not_called()
+        try_nous.assert_not_called()
+        mock_openai.assert_not_called()
 
     def test_custom_endpoint_when_no_nous(self, monkeypatch):
         """Custom endpoint is used when no OpenRouter/Nous keys are available.


### PR DESCRIPTION
## 变更

- 调整辅助模型 `auto` 默认链路，只保留 local/custom endpoint 与已配置的直接 API-key provider。
- 保留显式选择 OpenRouter/Nous 的能力，包括主模型或 `auxiliary.<task>.provider` 明确配置时的使用路径。
- 修正缺少 OpenRouter key 或 Nous 登录时的误导性 unhealthy 日志，仅真实欠费、限流等错误继续缓存 unhealthy。
- 更新 CLI/config 文案，并补齐辅助模型与 vision 路由相关测试。

## 验证

- `pytest tests/agent/test_auxiliary_client.py tests/hermes_cli/test_aux_config.py tests/agent/test_auxiliary_main_first.py`
