### PR TITLE
fix(desktop): 处理已存在其它 Hermes Agent 时桌面端无法启动飞书网关 (#168)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4293,7 +4293,11 @@ async function spawnPoolBackend(profile, entry) {
       HERMES_HOME,
       ...backend.env,
       HERMES_DASHBOARD_SESSION_TOKEN: token,
-      HERMES_WEB_DIST: webDist
+      HERMES_WEB_DIST: webDist,
+      // Mark every backend the desktop spawns as desktop-managed so the
+      // gateway restart it triggers won't silently hand off to a foreign
+      // gateway service / second install (issue #168).
+      HERMES_DESKTOP_MANAGED: '1'
     },
     shell: backend.shell,
     stdio: ['ignore', 'pipe', 'pipe']
@@ -4434,7 +4438,11 @@ async function startHermes() {
         HERMES_HOME,
         ...backend.env,
         HERMES_DASHBOARD_SESSION_TOKEN: token,
-        HERMES_WEB_DIST: webDist
+        HERMES_WEB_DIST: webDist,
+        // Mark the primary backend as desktop-managed so a gateway restart it
+        // triggers takes over its own gateway rather than silently restarting a
+        // pre-existing Windows gateway service / foreign install (issue #168).
+        HERMES_DESKTOP_MANAGED: '1'
       },
       shell: backend.shell,
       stdio: ['ignore', 'pipe', 'pipe']

--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -9,8 +9,10 @@ import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import {
   getMessagingPlatforms,
+  type MessagingConflictDetail,
   type MessagingEnvVarInfo,
   type MessagingPlatformInfo,
+  restartGateway,
   updateMessagingPlatform
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
@@ -413,6 +415,7 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
                     }
                   }))
                 }
+                onRefresh={() => void refreshPlatforms()}
                 onSave={() => void handleSave(selected)}
                 onToggle={enabled => void handleToggle(selected, enabled)}
                 platform={selected}
@@ -459,6 +462,7 @@ function PlatformDetail({
   edits,
   onClear,
   onEdit,
+  onRefresh,
   onSave,
   onToggle,
   platform,
@@ -467,6 +471,7 @@ function PlatformDetail({
   edits: Record<string, string>
   onClear: (key: string) => void
   onEdit: (key: string, value: string) => void
+  onRefresh: () => void
   onSave: () => void
   onToggle: (enabled: boolean) => void
   platform: MessagingPlatformInfo
@@ -505,11 +510,15 @@ function PlatformDetail({
             </div>
           </header>
 
-          {platform.error_message && (
-            <div className="flex items-start gap-2 rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height) text-destructive">
-              <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
-              <span>{platform.error_message}</span>
-            </div>
+          {isGatewayConflict(platform.error_code) ? (
+            <GatewayConflictNotice m={m} onRefresh={onRefresh} platform={platform} />
+          ) : (
+            platform.error_message && (
+              <div className="flex items-start gap-2 rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height) text-destructive">
+                <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                <span>{platform.error_message}</span>
+              </div>
+            )
           )}
 
           <section>
@@ -726,6 +735,80 @@ function MessagingField({
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
   return <h4 className="text-[0.7rem] font-semibold uppercase tracking-[0.14em] text-muted-foreground">{children}</h4>
+}
+
+// A `gateway_conflict_*` error_code means another Hermes Agent (a foreign
+// Windows service, or a second/WSL install over the shared loopback) is
+// blocking the desktop from starting the gateway with the params just saved
+// (issue #168). These get a richer prompt than a plain error string.
+function isGatewayConflict(errorCode: null | string | undefined): boolean {
+  return typeof errorCode === 'string' && errorCode.startsWith('gateway_conflict_')
+}
+
+function GatewayConflictNotice({
+  m,
+  onRefresh,
+  platform
+}: {
+  m: Translations['messaging']
+  onRefresh: () => void
+  platform: MessagingPlatformInfo
+}) {
+  const [busy, setBusy] = useState(false)
+  const [showHelp, setShowHelp] = useState(false)
+  const detail: MessagingConflictDetail = platform.error_detail || {}
+  const canTakeover = detail.can_takeover === true
+  const isPort = detail.kind === 'port'
+
+  const body = isPort ? m.conflictPortBody : m.conflictServiceBody
+  const helpSteps = isPort ? m.conflictHelpPort : m.conflictHelpService
+
+  async function handleTakeover() {
+    setBusy(true)
+    try {
+      await restartGateway(true)
+      notify({ kind: 'success', title: m.takeoverStarted, message: m.restartToReconnect })
+    } catch (err) {
+      notifyError(err, m.takeoverFailed)
+    } finally {
+      setBusy(false)
+      onRefresh()
+    }
+  }
+
+  return (
+    <div className="space-y-3 rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-3 text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height)">
+      <div className="flex items-start gap-2 text-amber-700 dark:text-amber-400">
+        <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+        <div className="min-w-0 space-y-1">
+          <p className="font-semibold">{m.conflictTitle}</p>
+          <p className="text-(--ui-text-secondary)">{body}</p>
+          {platform.error_message && (
+            <p className="break-words text-[0.66rem] text-(--ui-text-tertiary)">{platform.error_message}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button disabled={!canTakeover || busy} onClick={() => void handleTakeover()} size="sm" variant="textStrong">
+          {busy ? m.takingOver : m.forceTakeover}
+        </Button>
+        <Button onClick={() => setShowHelp(value => !value)} size="sm" variant="text">
+          {m.howToStopOthers}
+        </Button>
+      </div>
+
+      {!canTakeover && <p className="text-[0.66rem] text-(--ui-text-tertiary)">{m.conflictTakeoverUnavailable}</p>}
+
+      {showHelp && (
+        <ul className="ml-4 list-disc space-y-1 text-(--ui-text-secondary)">
+          {helpSteps.map(step => (
+            <li key={step}>{step}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
 }
 
 function PlatformHint({ platform }: { platform: MessagingPlatformInfo }) {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -67,6 +67,7 @@ export type {
   HermesConfig,
   HermesConfigRecord,
   LogsResponse,
+  MessagingConflictDetail,
   MessagingEnvVarInfo,
   MessagingHomeChannel,
   MessagingPlatformInfo,
@@ -634,9 +635,12 @@ export function setModelAssignment(body: ModelAssignmentRequest): Promise<ModelA
   })
 }
 
-export function restartGateway(): Promise<ActionResponse> {
+export function restartGateway(force = false): Promise<ActionResponse> {
+  // `force` requests a desktop-managed takeover: the backend stops any foreign
+  // gateway service / other local instance and runs a gateway the desktop owns
+  // in its place (issue #168).
   return window.hermesDesktop.api<ActionResponse>({
-    path: '/api/gateway/restart',
+    path: force ? '/api/gateway/restart?force=1' : '/api/gateway/restart',
     method: 'POST'
   })
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -365,6 +365,27 @@ export const en: Translations = {
     failedUpdate: name => `Failed to update ${name}`,
     failedSave: name => `Failed to save ${name}`,
     failedClear: key => `Failed to clear ${key}`,
+    conflictTitle: 'Another Hermes Agent is blocking the gateway',
+    conflictServiceBody:
+      "A previously-installed Hermes gateway service is running on this PC and isn't managed by the desktop app. Restarting it would use its own config and ignore the params you just saved.",
+    conflictPortBody:
+      'The messaging port is already in use by another Hermes Agent — typically a second install or one running inside WSL reachable over the shared localhost. The desktop gateway can’t bind it.',
+    conflictHelpService: [
+      'Stop the Windows service: run `hermes gateway service uninstall` in a terminal.',
+      'Or let the desktop take over: it stops that service and runs its own gateway.'
+    ],
+    conflictHelpPort: [
+      'If the other instance is in WSL, stop it there: `hermes gateway stop`.',
+      'If it’s a second Windows install, quit it (or stop its gateway), then retry.',
+      'Once the port is free, click “Force the desktop to take over”.'
+    ],
+    conflictTakeoverUnavailable:
+      'The conflicting instance isn’t reachable from here (e.g. it runs in WSL), so the desktop can’t stop it automatically. Stop it manually, then retry.',
+    forceTakeover: 'Force the desktop to take over',
+    takingOver: 'Taking over…',
+    howToStopOthers: 'How to stop the other instance',
+    takeoverStarted: 'Taking over the gateway',
+    takeoverFailed: 'Could not take over the gateway',
     fieldCopy: {},
     platformIntro: {}
   },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -325,6 +325,17 @@ export interface Translations {
     failedUpdate: (name: string) => string
     failedSave: (name: string) => string
     failedClear: (key: string) => string
+    conflictTitle: string
+    conflictServiceBody: string
+    conflictPortBody: string
+    conflictHelpService: string[]
+    conflictHelpPort: string[]
+    conflictTakeoverUnavailable: string
+    forceTakeover: string
+    takingOver: string
+    howToStopOthers: string
+    takeoverStarted: string
+    takeoverFailed: string
     fieldCopy: Record<string, { label?: string; help?: string; placeholder?: string }>
     platformIntro: Record<string, string>
   }

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -448,6 +448,27 @@ export const zh: Translations = {
     failedUpdate: name => `更新 ${name} 失败`,
     failedSave: name => `保存 ${name} 失败`,
     failedClear: key => `清除 ${key} 失败`,
+    conflictTitle: '检测到另一个 Hermes Agent 正在占用网关',
+    conflictServiceBody:
+      '这台电脑上有一个之前安装的 Hermes 网关服务正在运行，且不是桌面端托管的进程。直接重启它会沿用它自己的旧配置，忽略你刚保存的参数。',
+    conflictPortBody:
+      '消息端口已被另一个 Hermes Agent 占用——通常是第二个安装，或运行在 WSL 中、通过共享 localhost 可达的实例。桌面端网关无法绑定该端口。',
+    conflictHelpService: [
+      '停止 Windows 服务：在终端运行 `hermes gateway service uninstall`。',
+      '或让桌面端接管：它会停止该服务并运行自己托管的网关。'
+    ],
+    conflictHelpPort: [
+      '若另一个实例在 WSL 中，请在 WSL 里停止：`hermes gateway stop`。',
+      '若是第二个 Windows 安装，请退出它（或停止其网关）后重试。',
+      '端口释放后，点击「强制由桌面端接管并重启」。'
+    ],
+    conflictTakeoverUnavailable:
+      '冲突的实例无法从这里访问（例如它运行在 WSL 中），桌面端无法自动停止它。请手动停止后重试。',
+    forceTakeover: '强制由桌面端接管并重启',
+    takingOver: '正在接管…',
+    howToStopOthers: '查看如何停止其他实例',
+    takeoverStarted: '正在接管网关',
+    takeoverFailed: '接管网关失败',
     fieldCopy: {
       TELEGRAM_BOT_TOKEN: { label: 'Bot 令牌', help: '用 @BotFather 创建一个机器人,然后粘贴它给你的令牌。' },
       TELEGRAM_ALLOWED_USERS: {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -127,6 +127,19 @@ export interface MessagingHomeChannel {
   thread_id?: string
 }
 
+// Structured conflict info attached when the gateway can't start because
+// another Hermes Agent owns the resource (issue #168). `can_takeover` is true
+// only when the conflicting owner is a same-machine process the desktop can
+// stop; a WSL/cross-VM owner is false (stop-it-yourself guidance instead).
+export interface MessagingConflictDetail {
+  kind?: 'service' | 'port' | 'app_lock' | 'other' | string
+  can_takeover?: boolean
+  port?: number | null
+  owner_pid?: number | null
+  owner_home?: null | string
+  message?: null | string
+}
+
 export interface MessagingPlatformInfo {
   configured: boolean
   description: string
@@ -134,6 +147,7 @@ export interface MessagingPlatformInfo {
   enabled: boolean
   env_vars: MessagingEnvVarInfo[]
   error_code?: null | string
+  error_detail?: MessagingConflictDetail | null
   error_message?: null | string
   gateway_running: boolean
   home_channel?: MessagingHomeChannel | null

--- a/docs/issue-168-gateway-conflict-plan.md
+++ b/docs/issue-168-gateway-conflict-plan.md
@@ -1,0 +1,115 @@
+# Issue #168 — 桌面端无法启动飞书消息服务（已存在其它 Hermes Agent 时）
+
+分支：`fix/desktop-feishu-gateway-wsl-conflict-issue168`
+方案：**检测 + 清晰提示 + 一键接管**（混合方案）
+
+---
+
+## 1. 根因（已在代码中核实）
+
+桌面端（Electron）会**自己拉起并托管**一个 dashboard（随机空闲端口 `9120–9199`，固定 `HERMES_HOME`，带 `HERMES_DASHBOARD_SESSION_TOKEN`）。点击"保存并启动飞书消息服务"时调用 `POST /api/gateway/restart`（`hermes_cli/web_server.py:1395`），后者 spawn `hermes gateway restart`。失败有**两种触发源**，本质都是"真正（没）跑起来的网关不是桌面端托管的那个"：
+
+- **T1 — Windows 上已存在网关*服务*（计划任务/服务）**
+  `hermes gateway restart` 在 Windows 分支会先判断 `gateway_windows.is_installed()`（`hermes_cli/gateway.py:6393–6408`），若已安装服务，就去 `gateway_windows.restart()` 重启**那个**服务网关。该服务网关跑在它自己的 `HERMES_HOME` 下，**永远看不到桌面端刚保存的飞书参数** → "参数已存但服务起不来"。这正是"当前网关不是桌面端托管进程"的字面症状。
+  - 关键简化：桌面端从不安装 Windows 网关服务（它把网关当 dashboard 的子进程托管），因此**只要 `gateway_windows.is_installed()` 为真，对桌面端而言就是外部服务**。
+
+- **T2 — WSL 中另有一个 Hermes / 第二个 Windows 安装（不同 HERMES_HOME）**
+  重复实例守卫（`gateway/run.py:19507`）按 `HERMES_HOME` 隔离，跨 Windows↔WSL 边界看不到对方的 `gateway.pid`/锁。冲突通过**共享 localhost**暴露（WSL2 会把 `127.0.0.1` 转发）：飞书 webhook 端口默认 `8765`（`gateway/platforms/feishu.py:201`）被对方占用 → `connect()` 异常被吞成 `"Feishu startup failed: {exc}"`（`feishu.py:1686`，含 `Address already in use`）。
+  - 注意：飞书若用 websocket 长连接模式则不绑定本地端口，此时 T2 走 `acquire_scoped_lock("feishu-app", app_id)`（`feishu.py:1663`），但该锁在 `~/.local/state/hermes/gateway-locks/`，跨边界亦不可见 → 难以从 Windows 侧可靠探测。本方案对"端口冲突"做精确检测，对其余并发情形给出通用提示。
+
+### 现状链路（用于落点）
+- 网关把每平台状态写入 `gateway_state.json`：`write_runtime_status(platform=…, error_code=…, error_message=…)`（`gateway/status.py`）。
+- `/api/messaging/platforms` 经 `_messaging_platform_payload`（`web_server.py:3249`）透出 `state / error_code / error_message`。
+- 桌面端 `MessagingPlatformInfo` 已带 `error_code`/`error_message`；消息页 `apps/desktop/src/app/messaging/index.tsx:508–513` 目前只把 `error_message` 原样塞进一个红框。
+
+---
+
+## 2. 设计总览
+
+在 `gateway_state.json` 引入**结构化冲突信息**，在网关启动/重启时分类写入，经已有的 `/api/messaging/platforms` 透出，由桌面消息页渲染成**可操作的冲突面板**（中文）：
+
+- 「**强制由桌面端接管并重启**」——仅在**同机**冲突（T1 服务，或端口被本机可见 PID 占用）可用。
+- 「**查看如何停止其他实例**」——用于跨 VM（WSL）等无法接管的情形。
+
+### 桌面端托管信号
+桌面端在 spawn dashboard 时设 `HERMES_DESKTOP_MANAGED=1`；dashboard 继承后传给它 spawn 的 `hermes gateway restart` 子进程，后者据此判定"我应当托管网关"。
+
+### 结构化字段（新增）
+在每平台运行态里增加 `error_detail`：
+```jsonc
+"error_detail": {
+  "kind": "service" | "port" | "other",
+  "can_takeover": true,            // 同机可接管才为 true（跨 VM/WSL 为 false）
+  "port": 8765,                    // kind=="port" 时
+  "owner_pid": 1234,               // 本机可解析时
+  "owner_home": "C:\\Users\\..."   // 已知时
+}
+```
+`error_code` 取值：`gateway_conflict_service` / `gateway_conflict_port`（其余沿用旧值）。
+
+---
+
+## 3. 分文件改动计划
+
+### Phase 1 — Python：分类冲突并写结构化状态
+
+1. **`gateway/status.py`**
+   - 扩展 `write_runtime_status(...)` 增加可选 `error_detail: dict | None`，落到 `platforms[platform]["error_detail"]`。
+   - 新增 `classify_port_conflict(port: int) -> dict`：用 `psutil.net_connections()` 找本机占用该端口的 PID/cmdline；找到 → `{can_takeover: True, owner_pid, owner_home?}`；找不到（WSL2 relay 隐藏真实 PID）→ `{can_takeover: False}`。无 psutil 时优雅降级为 `can_takeover: False`。
+
+2. **`gateway/platforms/feishu.py`（及 `gateway/platforms/base.py` 共用 webhook 平台）**
+   - 在 `_connect_webhook`/`connect` 异常处理（`feishu.py:1684–1689`）识别 `OSError` 且 `errno in (EADDRINUSE, WSAEADDRINUSE/10048)`：置 `error_code="gateway_conflict_port"`，`error_message` 用更友好的文案，`error_detail=classify_port_conflict(self._webhook_port)`（补 `kind:"port"`,`port`）。
+   - app-lock 分支（`feishu.py:1671`）保持，但归一到 `error_detail={kind:"other", can_takeover:False}`。
+
+3. **`hermes_cli/gateway.py` — restart 分支（`6293–6450`）**
+   - 读取 `HERMES_DESKTOP_MANAGED`（新 helper `_is_desktop_managed()`）。
+   - **Windows 且 desktop-managed**：不再无条件 `gateway_windows.restart()`。
+     - 若 `gateway_windows.is_installed()`（=外部服务）且未带强制标志 → 写 `gateway_conflict_service`（含 `error_detail{kind:"service",can_takeover:True}`）并以清晰中/英文退出（非 0），**不**重启外部服务。
+     - 若带强制标志（`HERMES_GATEWAY_FORCE_TAKEOVER=1`）→ `gateway_windows.stop()` 停掉外部服务，然后 `run_gateway(replace=True)` 跑桌面端托管网关。
+   - desktop-managed 的**手动重启路径**（`6441–6449`）改用 `run_gateway(verbose=0, replace=True)`，确保接管自身陈旧网关。
+   - 非 desktop-managed 行为保持不变（回归零风险）。
+
+4. **`hermes_cli/web_server.py`**
+   - `/api/gateway/restart`（`1395–1407`）接收可选 `force`（query/body）；为真时给 spawn 的子进程注入 `HERMES_GATEWAY_FORCE_TAKEOVER=1`。确认 `_spawn_hermes_action` 透传/合并 env。
+   - `_messaging_platform_payload`（`3307–3328`）在返回里带上 `error_detail`。
+
+### Phase 2 — Desktop：透出冲突 + 动作
+
+5. **`apps/desktop/electron/main.cjs`**
+   - `startHermes`（spawn env `4374–4388`）与 `spawnPoolBackend`（`4241–4247`）的 env 增加 `HERMES_DESKTOP_MANAGED: '1'`。
+
+6. **`apps/desktop/src/hermes.ts`** — `restartGateway(force = false)`：`force` 时 POST `/api/gateway/restart?force=1`。
+
+7. **`apps/desktop/src/types/hermes.ts`** — `MessagingPlatformInfo`/`PlatformStatus` 增加可选 `error_detail`（`kind`,`can_takeover`,`port?`,`owner_pid?`,`owner_home?`）。
+
+8. **`apps/desktop/src/app/messaging/index.tsx`（`508–513`）**
+   - 当 `error_code ∈ {gateway_conflict_service, gateway_conflict_port}` 时，渲染冲突面板：标题 + 说明 + 按钮：
+     - 「强制由桌面端接管并重启」→ `restartGateway(true)` 后 `refreshPlatforms()`；仅 `error_detail.can_takeover` 为真时可点，否则禁用并解释。
+     - 「查看如何停止其他实例」→ 展开/跳转帮助（停止 WSL 内 Hermes / 停止 Windows 网关服务的步骤）。
+   - 其余 `error_code` 保持原红框展示。
+
+9. **`apps/desktop/src/i18n/{zh,en}.ts` + `types.ts`** — 新增 messaging 文案 key：`conflictTitle` / `conflictServiceBody` / `conflictPortBody` / `forceTakeover` / `howToStopOthers` / `takingOver` 等（zh 为主，en 同步，types 补类型）。
+
+### Phase 3 — 测试
+
+10. **Python**：`tests/hermes_cli/`（或 `tests/gateway/`）新增
+    - `classify_port_conflict` 的本机命中/未命中分支（mock psutil）。
+    - restart 的 desktop-managed 分支：mock `gateway_windows.is_installed()` → 验证未强制时写 `gateway_conflict_service` 且不调用 `restart()`；强制时调用 `stop()` + `run_gateway(replace=True)`。
+    - `write_runtime_status` 持久化 `error_detail` 往返。
+
+11. **Desktop**：渲染层测试覆盖冲突面板对 `error_code`/`can_takeover` 的映射（按钮可点/禁用）；`main.cjs` env 注入可加进现有 connection/bootstrap cjs 测试。
+
+---
+
+## 4. 风险与边界
+- **强制接管**会停掉用户已安装的 Windows 网关服务——仅经用户显式点击且面板有明确说明；非 desktop-managed/未强制时绝不动外部服务（默认零副作用）。
+- **跨 VM（WSL）**无法从 Windows 杀进程：`can_takeover:false`，只给停止指引，不做破坏性操作。
+- **websocket 模式的 WSL 并发**不可靠探测：本方案不强行猜测，端口冲突精确报、其余给通用并发提示。
+- 待实现时复核的假设：桌面端确实从不安装 Windows 网关服务（=已安装服务即外部）；`_spawn_hermes_action` 的 env 合并方式。
+
+---
+
+## 5. 验收对照（Issue 期望）
+- ✅ 不再停留在"参数已存但服务起不来"：要么一键接管成功，要么给出明确冲突+处置入口。
+- ✅ 明确处理"当前 Dashboard/网关非桌面端托管"场景（T1 服务 / T2 端口）。
+- ✅ 提供处置入口：强制接管（同机）/ 停止其他实例指引（WSL）。

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2062,12 +2062,23 @@ class BasePlatformAdapter(ABC):
             return
         self._write_runtime_status_safe("disconnected", platform_state="disconnected", error_code=None, error_message=None)
 
-    def _set_fatal_error(self, code: str, message: str, *, retryable: bool) -> None:
+    def _set_fatal_error(
+        self, code: str, message: str, *, retryable: bool, error_detail: Optional[dict] = None
+    ) -> None:
         self._running = False
         self._fatal_error_code = code
         self._fatal_error_message = message
         self._fatal_error_retryable = retryable
-        self._write_runtime_status_safe("fatal", platform_state="fatal", error_code=code, error_message=message)
+        # ``error_detail`` carries structured conflict info (e.g. a port-in-use
+        # owner) so the desktop can offer a targeted "force takeover" action.
+        # Pass ``None`` explicitly to clear any stale detail from a prior fault.
+        self._write_runtime_status_safe(
+            "fatal",
+            platform_state="fatal",
+            error_code=code,
+            error_message=message,
+            error_detail=error_detail,
+        )
 
     def _write_runtime_status_safe(self, context: str, **kwargs) -> None:
         """Write runtime status; log first failure per context at warning, rest at debug.

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import asyncio
 import collections
+import errno
 import hashlib
 import hmac
 import itertools
@@ -200,6 +201,31 @@ _DEFAULT_DEDUP_CACHE_SIZE = 2048
 _DEFAULT_WEBHOOK_HOST = "127.0.0.1"
 _DEFAULT_WEBHOOK_PORT = 8765
 _DEFAULT_WEBHOOK_PATH = "/feishu/webhook"
+
+# Windows surfaces "address already in use" as WSAEADDRINUSE (10048) rather than
+# the POSIX EADDRINUSE (98); accept both.
+_ADDRESS_IN_USE_ERRNOS = {errno.EADDRINUSE, getattr(errno, "WSAEADDRINUSE", 10048)}
+
+
+def _classify_address_in_use(exc: BaseException, port: int) -> Optional[dict]:
+    """Return structured conflict detail if ``exc`` is an address-in-use error.
+
+    Walks the exception chain (aiohttp/asyncio wrap the underlying ``OSError``)
+    looking for an ``EADDRINUSE``/``WSAEADDRINUSE`` errno. Returns ``None`` when
+    the failure is something else, so callers fall back to the generic error.
+    """
+    seen: set[int] = set()
+    cur: Optional[BaseException] = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        err_no = getattr(cur, "errno", None)
+        win_err = getattr(cur, "winerror", None)
+        if err_no in _ADDRESS_IN_USE_ERRNOS or win_err == 10048:
+            from gateway.status import classify_port_conflict
+
+            return classify_port_conflict(port)
+        cur = cur.__cause__ or cur.__context__
+    return None
 # ---------------------------------------------------------------------------
 # TTL, rate-limit and webhook security constants
 # ---------------------------------------------------------------------------
@@ -1673,7 +1699,16 @@ class FeishuAdapter(BasePlatformAdapter):
                     + " Stop the other gateway before starting a second Feishu websocket client."
                 )
                 logger.error("[Feishu] %s", message)
-                self._set_fatal_error("feishu_app_lock", message, retryable=False)
+                self._set_fatal_error(
+                    "feishu_app_lock",
+                    message,
+                    retryable=False,
+                    error_detail={
+                        "kind": "app_lock",
+                        "can_takeover": False,
+                        "owner_pid": owner_pid,
+                    },
+                )
                 return False
 
             self._loop = asyncio.get_running_loop()
@@ -1683,8 +1718,30 @@ class FeishuAdapter(BasePlatformAdapter):
             return True
         except Exception as exc:
             await self._release_app_lock()
+            # A webhook-mode bind that hits "address already in use" almost always
+            # means a *second* Hermes Agent (another Windows install, or one in
+            # WSL reachable over the shared loopback) already holds the port.
+            # Classify it so the desktop can show a targeted conflict prompt with
+            # a "force takeover" action when the owner is a local process.
+            conflict = _classify_address_in_use(exc, self._webhook_port)
+            if conflict is not None:
+                message = (
+                    "飞书消息服务无法启动：端口 "
+                    f"{self._webhook_port} 已被另一个 Hermes Agent 占用。"
+                    f"（{exc}）"
+                )
+                self._set_fatal_error(
+                    "gateway_conflict_port",
+                    message,
+                    retryable=True,
+                    error_detail=conflict,
+                )
+                logger.error(
+                    "[Feishu] Webhook port %s already in use: %s", self._webhook_port, exc, exc_info=True
+                )
+                return False
             message = f"Feishu startup failed: {exc}"
-            self._set_fatal_error("feishu_connect_error", message, retryable=True)
+            self._set_fatal_error("feishu_connect_error", message, retryable=True, error_detail=None)
             logger.error("[Feishu] Failed to connect: %s", exc, exc_info=True)
             return False
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -526,6 +526,7 @@ def write_runtime_status(
     platform_state: Any = _UNSET,
     error_code: Any = _UNSET,
     error_message: Any = _UNSET,
+    error_detail: Any = _UNSET,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
@@ -555,6 +556,12 @@ def write_runtime_status(
             platform_payload["error_code"] = error_code
         if error_message is not _UNSET:
             platform_payload["error_message"] = error_message
+        if error_detail is not _UNSET:
+            # ``None`` clears any prior structured detail; a dict replaces it.
+            if error_detail is None:
+                platform_payload.pop("error_detail", None)
+            else:
+                platform_payload["error_detail"] = error_detail
         platform_payload["updated_at"] = _utc_now_iso()
         payload["platforms"][platform] = platform_payload
 
@@ -564,6 +571,88 @@ def write_runtime_status(
 def read_runtime_status() -> Optional[dict[str, Any]]:
     """Read the persisted gateway runtime health/status information."""
     return _read_json_file(_get_runtime_status_path())
+
+
+def set_gateway_conflict(detail: Optional[dict]) -> None:
+    """Set or clear the top-level gateway-level conflict marker.
+
+    Written by the short-lived ``hermes gateway restart`` helper (not the live
+    gateway) when it declines to restart a foreign gateway, so — unlike
+    :func:`write_runtime_status` — it must NOT stamp pid/argv/start_time of the
+    helper over the record. Pass ``None`` to clear once a desktop-managed
+    gateway starts in the foreign one's place.
+    """
+    path = _get_runtime_status_path()
+    payload = _read_json_file(path) or _build_runtime_status_record()
+    payload.setdefault("platforms", {})
+    if detail is None:
+        payload.pop("gateway_conflict", None)
+    else:
+        record = dict(detail)
+        record.setdefault("updated_at", _utc_now_iso())
+        payload["gateway_conflict"] = record
+    _write_json_file(path, payload)
+
+
+def classify_port_conflict(port: int) -> dict[str, Any]:
+    """Describe who holds ``port`` so callers can decide whether takeover is safe.
+
+    Used when a platform (e.g. Feishu webhook) fails to bind because the port
+    is already in use. On a single machine the owner is a local PID we *could*
+    stop. But under WSL2 the foreign listener lives in a separate VM and only
+    surfaces on the Windows loopback via the localhost-forwarding relay — the
+    real PID is invisible to ``psutil`` here. We use that distinction to gate
+    the desktop's "force takeover" action: only same-machine owners can be
+    taken over; a WSL/cross-VM owner gets a "stop the other instance" hint
+    instead.
+
+    Returns a dict shaped for ``error_detail``:
+        {"kind": "port", "port": <int>, "can_takeover": <bool>,
+         "owner_pid": <int|None>, "owner_home": <str|None>}
+    ``can_takeover`` is True only when a local process owning the port is found.
+    """
+    detail: dict[str, Any] = {
+        "kind": "port",
+        "port": int(port),
+        "can_takeover": False,
+        "owner_pid": None,
+        "owner_home": None,
+    }
+    try:
+        import psutil  # type: ignore
+    except Exception:
+        # No psutil → can't resolve the owner; treat as non-takeover-able so we
+        # never claim a takeover we can't actually perform.
+        return detail
+
+    try:
+        for conn in psutil.net_connections(kind="inet"):
+            laddr = getattr(conn, "laddr", None)
+            if not laddr or getattr(laddr, "port", None) != int(port):
+                continue
+            # LISTEN sockets are the binders; a foreign relay won't expose a PID.
+            if conn.status not in (psutil.CONN_LISTEN, getattr(psutil, "CONN_NONE", "NONE")):
+                continue
+            owner_pid = getattr(conn, "pid", None)
+            if owner_pid is None:
+                # Port is held but the owning PID isn't visible (typical for the
+                # WSL2 loopback relay) → not takeover-able from here.
+                continue
+            detail["owner_pid"] = int(owner_pid)
+            detail["can_takeover"] = True
+            try:
+                env = psutil.Process(int(owner_pid)).environ()
+                home = env.get("HERMES_HOME")
+                if home:
+                    detail["owner_home"] = str(home)
+            except Exception:
+                pass
+            break
+    except Exception:
+        # net_connections can raise AccessDenied on locked-down hosts; degrade
+        # gracefully to "owner unknown, no takeover".
+        pass
+    return detail
 
 
 def remove_pid_file() -> None:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5841,6 +5841,83 @@ def _dispatch_all_via_service_manager_if_s6(action: str) -> bool:
 
 
 
+def _is_desktop_managed() -> bool:
+    """True when this CLI was spawned by the Hermes Desktop app.
+
+    The desktop sets ``HERMES_DESKTOP_MANAGED=1`` on the dashboard backend it
+    owns; that env propagates to the ``hermes gateway restart`` action the
+    dashboard spawns. We use it to keep the desktop from silently restarting a
+    *foreign* gateway (a pre-existing Windows service, or a second install)
+    that runs under a different ``HERMES_HOME`` and would never pick up the
+    channel params the desktop just saved (issue #168).
+    """
+    return os.environ.get("HERMES_DESKTOP_MANAGED") == "1"
+
+
+def _record_gateway_conflict_service() -> None:
+    """Mark that a foreign Windows gateway service is blocking a desktop start.
+
+    Surfaced to the desktop via the gateway runtime status so the messaging UI
+    can offer a one-click "force takeover" instead of a dead-end error.
+    """
+    try:
+        from gateway.status import set_gateway_conflict
+
+        set_gateway_conflict(
+            {
+                "kind": "service",
+                "can_takeover": True,
+                "message": (
+                    "检测到 Windows 上已安装的 Hermes 网关服务（非桌面端托管）。"
+                    "桌面端不会自动重启它，否则会用旧配置覆盖刚保存的参数。"
+                ),
+            }
+        )
+    except Exception:
+        pass
+
+
+def _free_conflicting_local_gateways() -> int:
+    """Terminate *local* gateways running under a different ``HERMES_HOME``.
+
+    Only invoked on an explicit desktop "force takeover". WSL/cross-VM gateways
+    are invisible to ``psutil`` here, so this only ever touches same-machine
+    processes; our own / same-home gateway is left to the ``--replace`` path.
+    Returns the number of processes signalled.
+    """
+    try:
+        import psutil  # type: ignore
+    except Exception:
+        return 0
+    our_home = str(get_hermes_home().resolve())
+    me = os.getpid()
+    patterns = ("gateway run", "gateway/run.py", "hermes gateway", "hermes-gateway")
+    killed = 0
+    for proc in psutil.process_iter(["pid", "cmdline", "environ"]):
+        try:
+            pid = proc.info.get("pid")
+            if pid in (None, me):
+                continue
+            cmdline = " ".join(proc.info.get("cmdline") or []).lower()
+            if not any(p in cmdline for p in patterns):
+                continue
+            env = proc.info.get("environ") or {}
+            home = env.get("HERMES_HOME")
+            if home:
+                try:
+                    if str(Path(home).resolve()) == our_home:
+                        continue  # our own / same-home gateway — handled by --replace
+                except Exception:
+                    pass
+            proc.terminate()
+            killed += 1
+        except Exception:
+            continue
+    if killed:
+        _wait_for_gateway_exit(timeout=8.0, force_after=4.0)
+    return killed
+
+
 def gateway_command(args):
     """Handle gateway subcommands."""
     try:
@@ -6393,19 +6470,53 @@ def _gateway_command_inner(args):
         elif is_windows():
             from hermes_cli import gateway_windows
 
-            # Prefer the Windows-specific restart path: it supports both
-            # registered Scheduled Task / Startup installs and no-service
-            # detached restarts.  In the normal successful Telegram-triggered
-            # restart flow, this avoids the generic foreground run_gateway()
-            # path that can be reaped with the old gateway process.  If the
-            # Windows backend raises, intentionally preserve the existing
-            # generic failure fallback below.
-            service_configured = gateway_windows.is_installed()
-            try:
-                gateway_windows.restart()
-                return
-            except (subprocess.CalledProcessError, RuntimeError, OSError):
-                pass
+            desktop_managed = _is_desktop_managed()
+            force_takeover = os.getenv("HERMES_GATEWAY_FORCE_TAKEOVER") == "1"
+            service_installed = gateway_windows.is_installed()
+
+            if desktop_managed and service_installed and not force_takeover:
+                # The desktop runs the gateway as a child of its dashboard and
+                # never installs a Windows service. An installed service is
+                # therefore a *foreign* gateway: restarting it would run under
+                # its own HERMES_HOME and never see the channel params the
+                # desktop just saved (issue #168). Surface a conflict the
+                # desktop can resolve with a one-click takeover instead of
+                # silently restarting the wrong gateway.
+                _record_gateway_conflict_service()
+                print_error(
+                    "检测到已安装的 Windows Hermes 网关服务（非桌面端托管）。\n"
+                    "  已拒绝重启该外部网关，否则会用旧配置覆盖刚保存的参数。\n"
+                    "  在桌面端点击「强制由桌面端接管并重启」，或先停止该服务："
+                    "  hermes gateway service uninstall"
+                )
+                sys.exit(2)
+
+            if desktop_managed:
+                # Explicit takeover: stop the foreign service + any other local
+                # gateway under a different HERMES_HOME, then run a
+                # desktop-managed gateway via the manual --replace path below.
+                if force_takeover:
+                    if service_installed:
+                        try:
+                            gateway_windows.stop()
+                        except (subprocess.CalledProcessError, RuntimeError, OSError):
+                            pass
+                    _free_conflicting_local_gateways()
+                service_configured = False
+            else:
+                # Prefer the Windows-specific restart path: it supports both
+                # registered Scheduled Task / Startup installs and no-service
+                # detached restarts.  In the normal successful Telegram-triggered
+                # restart flow, this avoids the generic foreground run_gateway()
+                # path that can be reaped with the old gateway process.  If the
+                # Windows backend raises, intentionally preserve the existing
+                # generic failure fallback below.
+                service_configured = service_installed
+                try:
+                    gateway_windows.restart()
+                    return
+                except (subprocess.CalledProcessError, RuntimeError, OSError):
+                    pass
 
         if not service_available:
             # systemd/launchd restart failed — check if linger is the issue
@@ -6444,9 +6555,21 @@ def _gateway_command_inner(args):
 
             _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
 
+            # A desktop-managed start takes over its own stale gateway (and any
+            # we just freed during a force-takeover) via --replace, and clears
+            # any lingering conflict marker now that we're starting our own.
+            desktop_managed = _is_desktop_managed()
+            if desktop_managed:
+                try:
+                    from gateway.status import set_gateway_conflict
+
+                    set_gateway_conflict(None)
+                except Exception:
+                    pass
+
             # Start fresh
             print("Starting gateway...")
-            run_gateway(verbose=0)
+            run_gateway(verbose=0, replace=desktop_managed)
 
     elif subcmd == "status":
         deep = getattr(args, "deep", False)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1337,11 +1337,15 @@ def _record_completed_action(name: str, message: str, exit_code: int = 1) -> Non
     _ACTION_RESULTS[name] = {"exit_code": exit_code, "pid": None}
 
 
-def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
+def _spawn_hermes_action(
+    subcommand: List[str], name: str, extra_env: Optional[Dict[str, str]] = None
+) -> subprocess.Popen:
     """Spawn ``hermes <subcommand>`` detached and record the Popen handle.
 
     Uses the running interpreter's ``hermes_cli.main`` module so the action
-    inherits the same venv/PYTHONPATH the web server is using.
+    inherits the same venv/PYTHONPATH the web server is using. ``extra_env``
+    overlays additional environment variables on the child (e.g. a one-shot
+    ``HERMES_GATEWAY_FORCE_TAKEOVER`` for a desktop-initiated takeover).
     """
     log_file_name = _ACTION_LOG_FILES[name]
     _ACTION_LOG_DIR.mkdir(parents=True, exist_ok=True)
@@ -1358,7 +1362,7 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
         "stdin": subprocess.DEVNULL,
         "stdout": log_file,
         "stderr": subprocess.STDOUT,
-        "env": {**os.environ, "HERMES_NONINTERACTIVE": "1"},
+        "env": {**os.environ, "HERMES_NONINTERACTIVE": "1", **(extra_env or {})},
     }
     if sys.platform == "win32":
         popen_kwargs["creationflags"] = (
@@ -1393,10 +1397,20 @@ def _tail_lines(path: Path, n: int) -> List[str]:
 
 
 @app.post("/api/gateway/restart")
-async def restart_gateway():
-    """Kick off a ``hermes gateway restart`` in the background."""
+async def restart_gateway(force: bool = False):
+    """Kick off a ``hermes gateway restart`` in the background.
+
+    ``force=1`` requests a desktop-managed *takeover*: the spawned restart
+    stops any foreign Windows gateway service / other local gateway and runs a
+    gateway the desktop owns in its place (issue #168). Without it, a
+    desktop-managed restart that finds a foreign service declines and records a
+    conflict for the UI rather than restarting the wrong gateway.
+    """
+    extra_env = {"HERMES_GATEWAY_FORCE_TAKEOVER": "1"} if force else None
     try:
-        proc = _spawn_hermes_action(["gateway", "restart"], "gateway-restart")
+        proc = _spawn_hermes_action(
+            ["gateway", "restart"], "gateway-restart", extra_env=extra_env
+        )
     except Exception as exc:
         _log.exception("Failed to spawn gateway restart")
         raise HTTPException(status_code=500, detail=f"Failed to restart gateway: {exc}")
@@ -3304,6 +3318,39 @@ def _messaging_platform_payload(
     elif not gateway_running and not state:
         state = "gateway_stopped"
 
+    error_code = (
+        runtime_platform.get("error_code")
+        if isinstance(runtime_platform, dict)
+        else None
+    )
+    error_message = (
+        runtime_platform.get("error_message")
+        if isinstance(runtime_platform, dict)
+        else None
+    )
+    error_detail = (
+        runtime_platform.get("error_detail")
+        if isinstance(runtime_platform, dict)
+        else None
+    )
+
+    # A gateway-level conflict (e.g. a foreign Windows service the desktop
+    # declined to restart, issue #168) isn't tied to one platform's runtime
+    # record, so surface it on each enabled+configured platform that doesn't
+    # already carry its own more-specific error. This drives the desktop's
+    # conflict prompt + one-click takeover on the channel the user is setting up.
+    gateway_conflict = runtime.get("gateway_conflict") if isinstance(runtime, dict) else None
+    if (
+        enabled
+        and configured
+        and not error_code
+        and isinstance(gateway_conflict, dict)
+    ):
+        kind = gateway_conflict.get("kind") or "service"
+        error_code = f"gateway_conflict_{kind}"
+        error_message = gateway_conflict.get("message") or error_message
+        error_detail = gateway_conflict
+
     return {
         "id": platform_id,
         "name": entry["name"],
@@ -3313,16 +3360,9 @@ def _messaging_platform_payload(
         "configured": configured,
         "gateway_running": gateway_running,
         "state": state,
-        "error_code": (
-            runtime_platform.get("error_code")
-            if isinstance(runtime_platform, dict)
-            else None
-        ),
-        "error_message": (
-            runtime_platform.get("error_message")
-            if isinstance(runtime_platform, dict)
-            else None
-        ),
+        "error_code": error_code,
+        "error_message": error_message,
+        "error_detail": error_detail,
         "updated_at": (
             runtime_platform.get("updated_at")
             if isinstance(runtime_platform, dict)

--- a/tests/gateway/test_gateway_conflict.py
+++ b/tests/gateway/test_gateway_conflict.py
@@ -1,0 +1,231 @@
+"""Tests for the desktop/foreign gateway conflict handling (issue #168).
+
+Covers:
+- ``gateway.status``: structured ``error_detail`` round-trip, the top-level
+  ``gateway_conflict`` marker, and ``classify_port_conflict`` owner resolution.
+- ``feishu._classify_address_in_use``: EADDRINUSE detection through a wrapped
+  exception chain (incl. the Windows WSAEADDRINUSE code).
+- ``hermes_cli.gateway`` restart path: a desktop-managed restart that finds a
+  foreign Windows gateway service declines (records a conflict) unless an
+  explicit force-takeover is requested; non-desktop restarts are unchanged.
+"""
+
+import errno
+import os
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture()
+def runtime_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_RUNTIME_DIR", str(tmp_path))
+    # Reimport-safe: status reads the env each call, so just clear caches via env.
+    return tmp_path
+
+
+# --------------------------------------------------------------------------- #
+# gateway.status
+# --------------------------------------------------------------------------- #
+def test_error_detail_round_trip_and_clear(runtime_dir):
+    import gateway.status as gs
+
+    gs.write_runtime_status(
+        platform="feishu",
+        platform_state="fatal",
+        error_code="gateway_conflict_port",
+        error_message="boom",
+        error_detail={"kind": "port", "port": 8765, "can_takeover": False},
+    )
+    feishu = gs.read_runtime_status()["platforms"]["feishu"]
+    assert feishu["error_code"] == "gateway_conflict_port"
+    assert feishu["error_detail"] == {"kind": "port", "port": 8765, "can_takeover": False}
+
+    # Passing None clears the structured detail without touching other fields.
+    gs.write_runtime_status(platform="feishu", error_detail=None)
+    feishu = gs.read_runtime_status()["platforms"]["feishu"]
+    assert "error_detail" not in feishu
+    assert feishu["error_code"] == "gateway_conflict_port"
+
+
+def test_set_gateway_conflict_set_and_clear(runtime_dir):
+    import gateway.status as gs
+
+    gs.set_gateway_conflict({"kind": "service", "can_takeover": True, "message": "svc"})
+    rec = gs.read_runtime_status()
+    assert rec["gateway_conflict"]["kind"] == "service"
+    assert rec["gateway_conflict"]["can_takeover"] is True
+    assert "updated_at" in rec["gateway_conflict"]
+
+    gs.set_gateway_conflict(None)
+    assert "gateway_conflict" not in gs.read_runtime_status()
+
+
+def test_classify_port_conflict_no_psutil(runtime_dir, monkeypatch):
+    import gateway.status as gs
+
+    # Force the ImportError path → safe, non-takeover-able default.
+    monkeypatch.setitem(sys.modules, "psutil", None)
+    detail = gs.classify_port_conflict(8765)
+    assert detail == {
+        "kind": "port",
+        "port": 8765,
+        "can_takeover": False,
+        "owner_pid": None,
+        "owner_home": None,
+    }
+
+
+def test_classify_port_conflict_local_owner(runtime_dir, monkeypatch):
+    import gateway.status as gs
+
+    fake_conn = types.SimpleNamespace(
+        laddr=types.SimpleNamespace(port=8765),
+        status="LISTEN",
+        pid=4321,
+    )
+
+    class FakeProc:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def environ(self):
+            return {"HERMES_HOME": "/home/u/.hermes"}
+
+    fake_psutil = types.SimpleNamespace(
+        CONN_LISTEN="LISTEN",
+        CONN_NONE="NONE",
+        net_connections=lambda kind="inet": [fake_conn],
+        Process=FakeProc,
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+    detail = gs.classify_port_conflict(8765)
+    assert detail["can_takeover"] is True
+    assert detail["owner_pid"] == 4321
+    assert detail["owner_home"] == "/home/u/.hermes"
+
+
+# --------------------------------------------------------------------------- #
+# feishu._classify_address_in_use
+# --------------------------------------------------------------------------- #
+def test_classify_address_in_use_detects_eaddrinuse(runtime_dir):
+    from gateway.platforms.feishu import _classify_address_in_use
+
+    wrapped = RuntimeError("startup failed")
+    wrapped.__cause__ = OSError(errno.EADDRINUSE, "Address already in use")
+    detail = _classify_address_in_use(wrapped, 8765)
+    assert detail is not None
+    assert detail["kind"] == "port"
+    assert detail["port"] == 8765
+
+
+def test_classify_address_in_use_windows_code(runtime_dir):
+    from gateway.platforms.feishu import _classify_address_in_use
+
+    win = OSError()
+    win.errno = 10048  # WSAEADDRINUSE
+    assert _classify_address_in_use(win, 8765) is not None
+
+
+def test_classify_address_in_use_ignores_other_errors(runtime_dir):
+    from gateway.platforms.feishu import _classify_address_in_use
+
+    assert _classify_address_in_use(ValueError("nope"), 8765) is None
+
+
+# --------------------------------------------------------------------------- #
+# hermes_cli.gateway restart path
+# --------------------------------------------------------------------------- #
+def _restart_args():
+    return types.SimpleNamespace(gateway_command="restart", system=False, all=False)
+
+
+@pytest.fixture()
+def windows_restart_env(monkeypatch):
+    """Drive the restart branch to the Windows path, desktop-managed."""
+    import hermes_cli.gateway as gw
+
+    monkeypatch.setenv("HERMES_DESKTOP_MANAGED", "1")
+    monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+    monkeypatch.setattr(gw, "is_windows", lambda: True)
+    monkeypatch.setattr(gw, "is_macos", lambda: False)
+    monkeypatch.setattr(gw, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gw, "_dispatch_via_service_manager_if_s6", lambda _x: False)
+    monkeypatch.setattr(gw, "_dispatch_all_via_service_manager_if_s6", lambda _x: False)
+    return gw
+
+
+def test_desktop_managed_foreign_service_declines(runtime_dir, windows_restart_env, monkeypatch):
+    gw = windows_restart_env
+    monkeypatch.delenv("HERMES_GATEWAY_FORCE_TAKEOVER", raising=False)
+
+    fake_win = types.SimpleNamespace(
+        is_installed=lambda: True,
+        restart=mock.Mock(),
+        stop=mock.Mock(),
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.gateway_windows", fake_win)
+    run_gateway = mock.Mock()
+    monkeypatch.setattr(gw, "run_gateway", run_gateway)
+
+    with pytest.raises(SystemExit) as exc:
+        gw._gateway_command_inner(_restart_args())
+    assert exc.value.code == 2
+
+    # Declined: did not restart the foreign service, did not run our own,
+    # and recorded a takeover-able conflict for the desktop.
+    fake_win.restart.assert_not_called()
+    run_gateway.assert_not_called()
+    import gateway.status as gs
+
+    assert gs.read_runtime_status()["gateway_conflict"]["kind"] == "service"
+
+
+def test_desktop_managed_force_takeover(runtime_dir, windows_restart_env, monkeypatch):
+    gw = windows_restart_env
+    monkeypatch.setenv("HERMES_GATEWAY_FORCE_TAKEOVER", "1")
+
+    fake_win = types.SimpleNamespace(
+        is_installed=lambda: True,
+        restart=mock.Mock(),
+        stop=mock.Mock(),
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.gateway_windows", fake_win)
+    monkeypatch.setattr(gw, "_free_conflicting_local_gateways", lambda: 0)
+    monkeypatch.setattr(gw, "stop_profile_gateway", lambda: False)
+    monkeypatch.setattr(gw, "_wait_for_gateway_exit", lambda **k: None)
+    run_gateway = mock.Mock()
+    monkeypatch.setattr(gw, "run_gateway", run_gateway)
+
+    gw._gateway_command_inner(_restart_args())
+
+    # Took over: stopped the foreign service and ran a desktop-managed gateway
+    # with --replace.
+    fake_win.stop.assert_called_once()
+    fake_win.restart.assert_not_called()
+    run_gateway.assert_called_once()
+    assert run_gateway.call_args.kwargs.get("replace") is True
+
+
+def test_non_desktop_windows_uses_service_restart(runtime_dir, windows_restart_env, monkeypatch):
+    gw = windows_restart_env
+    monkeypatch.delenv("HERMES_DESKTOP_MANAGED", raising=False)  # not desktop-managed
+    monkeypatch.delenv("HERMES_GATEWAY_FORCE_TAKEOVER", raising=False)
+
+    fake_win = types.SimpleNamespace(
+        is_installed=lambda: True,
+        restart=mock.Mock(),
+        stop=mock.Mock(),
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.gateway_windows", fake_win)
+    run_gateway = mock.Mock()
+    monkeypatch.setattr(gw, "run_gateway", run_gateway)
+
+    gw._gateway_command_inner(_restart_args())
+
+    # Unchanged legacy behavior: restart the installed service, never run our own.
+    fake_win.restart.assert_called_once()
+    run_gateway.assert_not_called()


### PR DESCRIPTION
## 背景

Ref: Eynzof/Hermes-CN-Desktop#168

较多 Windows 用户反馈：**以前在 Windows 上装过 Hermes Agent** 的情况下，用中文社区桌面版完成飞书扫码、保存参数后点击「保存并启动飞书消息服务」，网关拒绝启动，提示类似“当前 dashboard 不是桌面端托管进程”。用户停留在“参数已存但飞书消息服务起不来”的状态。

## 根因（已在代码中核实，两种触发源、本质相同）

桌面端（Electron）自己拉起并托管一个 dashboard，点击保存后调用 `POST /api/gateway/restart` → spawn `hermes gateway restart`。失败的本质都是「真正（没）跑起来的网关不是桌面端托管的那个」：

- **T1 · Windows 已装网关服务**：`hermes gateway restart` 在 Windows 会优先 `gateway_windows.restart()`（`hermes_cli/gateway.py`），去重启那个**外部服务**网关——它跑在自己的 `HERMES_HOME` 下，永远看不到桌面端刚保存的飞书参数。桌面端从不安装 Windows 网关服务，所以“已安装服务”对桌面端即外部。
- **T2 · WSL / 第二个安装（不同 HERMES_HOME）**：重复实例守卫按 `HERMES_HOME` 隔离，跨 Windows↔WSL 看不到对方；冲突通过共享 localhost 暴露（WSL2 转发 127.0.0.1），飞书 webhook 端口 `8765` 被占 → 被吞成模糊的 `"Feishu startup failed: …"`。

## 方案：检测 + 清晰提示 + 一键接管（混合）

- 桌面端 spawn dashboard 时注入 `HERMES_DESKTOP_MANAGED=1`，让 Python 侧能判定“应由桌面端托管网关”。
- **不再静默重启外部 Windows 服务**：desktop-managed 且发现外部服务时，未带 `force` → 记录结构化冲突 `gateway_conflict_service` 并拒绝（exit 2）；带 `force`（用户点「强制接管」）→ 停掉外部服务 / 其它本机网关并以 `--replace` 跑桌面端托管网关。desktop-managed 的手动重启统一 `--replace`。
- 飞书 `connect` 对 `EADDRINUSE`（含 Windows `WSAEADDRINUSE`）分类为 `gateway_conflict_port`，用 psutil 解析占用者是否为**本机可接管**进程（WSL/跨 VM → 不可接管）。
- 经 `gateway_state.json` → `/api/messaging/platforms` 透出结构化 `error_detail`；桌面消息页渲染冲突面板：**「强制由桌面端接管并重启」**（同机可点）/ **「查看如何停止其他实例」**（WSL 等不可接管时给指引）。
- `POST /api/gateway/restart` 新增 `force` 参数，透传一次性 `HERMES_GATEWAY_FORCE_TAKEOVER`。

## 改动文件

**Python**
- `gateway/status.py` — `write_runtime_status` 增加 `error_detail`；新增 `set_gateway_conflict`、`classify_port_conflict`。
- `gateway/platforms/base.py` — `_set_fatal_error` 支持 `error_detail`。
- `gateway/platforms/feishu.py` — `_classify_address_in_use`，端口冲突归类。
- `hermes_cli/gateway.py` — restart 的 desktop-managed 分支 + 强制接管 + 冲突标记/清除。
- `hermes_cli/web_server.py` — `/api/gateway/restart?force=1`；payload 透出 `error_detail` 与网关级冲突。

**Desktop**
- `apps/desktop/electron/main.cjs` — 两处 spawn 注入 `HERMES_DESKTOP_MANAGED=1`。
- `apps/desktop/src/hermes.ts` — `restartGateway(force)`。
- `apps/desktop/src/types/hermes.ts` — `MessagingConflictDetail` 类型 + `error_detail`。
- `apps/desktop/src/app/messaging/index.tsx` — 冲突面板与一键接管。
- `apps/desktop/src/i18n/{types,en,zh}.ts` — 新增文案。

**测试 / 文档**
- `tests/gateway/test_gateway_conflict.py` — 状态往返、端口冲突分类、EADDRINUSE 识别、重启分支三路径。
- `docs/issue-168-gateway-conflict-plan.md` — 根因与设计说明。

## 验证

- 5 个改动 Python 文件 + 测试均 `py_compile` 通过。
- 用 stdlib `unittest.mock` 在本地 runtime 验证了重启分支 4 个场景：外部服务拒绝(exit 2)+记录冲突 / 强制接管(停服务+`run_gateway(replace=True)`) / 非 desktop-managed 维持原行为 / desktop-managed 无服务正常 `--replace` 启动并清除陈旧冲突。
- 状态与飞书分类函数单测全部通过（psutil 缺失时安全降级为不可接管）。
- ⚠️ 桌面端 TS 因环境未安装依赖（无 `node_modules`）未跑 `tsc`/构建；已做人工类型核对（类型/导入/Button 变体/i18n key 齐全）。建议 CI 跑一遍 `type-check` 与单测。

## 范围与边界

- 非 desktop-managed 行为完全不变（零回归）。
- 强制接管仅经用户显式点击触发，且只停**同机**服务/进程；跨 VM（WSL）不做破坏性操作，仅给停止指引。
- 本次按 issue 聚焦 Windows；Linux 上“预装 systemd 网关服务”的等价情形仍走原 systemd 路径（端口冲突检测跨平台生效）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)