### PR TITLE
perf(dashboard): prewarm run_agent import at boot to cut first-conversation cold start

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12399,6 +12399,33 @@ def cmd_dashboard(args):
         # the missing-provider state if it matters.
         print(f"⚠ Plugin discovery failed: {exc}", file=sys.stderr)
 
+    # Pre-warm the heavy ``from run_agent import AIAgent`` import off-thread
+    # while uvicorn is still binding/serving. The first chat session's deferred
+    # agent build (tui_gateway.server._make_agent) otherwise pays this import —
+    # model_tools' module-level ``discover_builtin_tools()`` plus the run_agent /
+    # model_metadata / provider-adapter parse — on the user's critical path,
+    # which is the single biggest first-conversation stall. ``discover_plugins()``
+    # already ran above on the main thread, so the transitive discovery this
+    # triggers is a cached no-op (no registry race). Imports are idempotent and
+    # cached, so the later on-demand ``_make_agent`` import just hits
+    # ``sys.modules``. Daemon + exception-isolated so it can never block startup
+    # or mask a real import error (the on-demand import still surfaces it). Opt
+    # out with ``HERMES_DASHBOARD_PREWARM_AGENT=0``.
+    if os.getenv("HERMES_DASHBOARD_PREWARM_AGENT", "1").strip().lower() not in {
+        "0", "false", "no", "off",
+    }:
+        def _prewarm_agent_import() -> None:
+            try:
+                from run_agent import AIAgent  # noqa: F401  # warms model_tools + adapters
+            except Exception:
+                logger.debug("dashboard agent-import prewarm failed", exc_info=True)
+
+        threading.Thread(
+            target=_prewarm_agent_import,
+            daemon=True,
+            name="dashboard-agent-prewarm",
+        ).start()
+
     from hermes_cli.web_server import start_server
 
     # The in-browser Chat tab (the embedded TUI over PTY/WebSocket) is always


### PR DESCRIPTION
## 背景

社区桌面版"对话冷启动慢"排查中发现:首次开聊时,延迟构建的 agent(`tui_gateway.server._make_agent`)要在用户关键路径上执行 `from run_agent import AIAgent` —— 这句会触发 `model_tools` 模块级的 `discover_builtin_tools()` 以及 `run_agent` / `model_metadata` / provider adapter 一大堆模块的解析。

**实测冷态约 3.0–3.8s**,是首次对话最大的一处卡顿;而 FastAPI lifespan 在 server 启动时并不预热 agent。

> 注:本仓库原有的预热原语(`agent/httpx_clients.py` 的 SSL context 进程级缓存、跳过已声明模型的 live 校验、`_wait_agent()` 模型切换协调、`session.create` 后 50ms 延迟构建)**均未改动且完好**;本 PR 只是把那句重导入提前,让它和启动重叠,而不是压在首条消息上。

## 改动

`cmd_dashboard` 在 `discover_plugins()` 之后(已在主线程跑过,故此处的传递式 discovery 是已缓存的 no-op,无注册表竞争)、`start_server()`/uvicorn 绑定之前,启动一个**守护线程**预热 `from run_agent import AIAgent`。导入在 uvicorn 启动 + 用户阅读界面期间完成,之后按需的 `_make_agent` 导入直接命中 `sys.modules`(~0ms),而不是付 ~3s。

- 幂等 + 缓存;守护线程 + 异常隔离 —— 绝不阻塞启动,也不会吞掉真实导入错误(按需导入仍会照常抛出)。
- 可通过 `HERMES_DASHBOARD_PREWARM_AGENT=0` 关闭。

## 验证

- `from run_agent import AIAgent`:冷态 **3.84s / 2.96s**,缓存后 **0.0ms** —— 证实预热把 ~3s 从首条对话关键路径上挪走。
- `tests/agent/test_auxiliary_client.py` + `test_auxiliary_main_first.py`:**228 passed**。
- `python -m py_compile hermes_cli/main.py`:通过。

## 影响面

仅 `hermes_cli/main.py` 的 dashboard 启动路径,+27 行,纯增量。standalone dashboard 用户同样受益(更快的首次开聊),桌面/Web 均适用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
