### PR TITLE
[codex] 修复 Windows PowerShell 终端对象输出丢失

### DIFF
--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -18,6 +18,7 @@ and ``os.path.isdir`` so the MSYS path tests as "missing" exactly like
 on the real OS.
 """
 
+import shutil
 from unittest.mock import patch
 
 
@@ -140,6 +141,40 @@ class TestUpdateCwdWindowsMsys:
             env._update_cwd({"output": "", "returncode": 0})
 
         assert env.cwd == str(new_dir)
+
+
+class TestPowerShellWrapperOutput:
+    def test_object_output_survives_wrapper_exit(self, monkeypatch, tmp_path):
+        """PowerShell object output must be formatted before wrapper ``exit``.
+
+        Native PowerShell commands like ``Get-Location`` and ``Test-Path``
+        write objects, not plain text.  If the wrapper immediately calls
+        ``exit`` after ``Invoke-Expression``, non-interactive hosts can drop
+        that formatted output and the terminal tool appears to return an
+        empty result even though the command succeeded.
+        """
+        shell = shutil.which("pwsh") or shutil.which("powershell.exe")
+        if not shell:
+            import pytest
+
+            pytest.skip("PowerShell executable is not available")
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local_mod, "_resolve_shell", lambda: ("powershell", shell))
+
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+        try:
+            result = env.execute(
+                "Get-Location; Test-Path -LiteralPath .",
+                timeout=10,
+            )
+        finally:
+            env.cleanup()
+
+        assert result["returncode"] == 0
+        assert str(tmp_path) in result["output"]
+        assert "True" in result["output"]
+        assert env._cwd_marker not in result["output"]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -605,15 +605,20 @@ class LocalEnvironment(BaseEnvironment):
             f"$ErrorActionPreference = 'Continue'",
             f"Set-Location -LiteralPath '{quoted_cwd}' -ErrorAction SilentlyContinue",
             f"if ($?) {{ Set-Location -LiteralPath '{quoted_cwd}' }} else {{ exit 126 }}",
-            # Run the command
-            f"Invoke-Expression '{escaped}'",
+            # Run the command and force PowerShell's formatting pipeline to
+            # flush before the wrapper exits.  Without ``Out-Default``,
+            # object-producing commands such as ``pwd`` / ``Get-Location`` or
+            # mixed statements like ``Get-Location; Test-Path ...`` can return
+            # an empty stdout when followed by ``exit`` in non-interactive
+            # PowerShell hosts.
+            f"Invoke-Expression '{escaped}' | Out-Default",
             f"$hermes_ec = $LASTEXITCODE",
             # Write CWD to temp file
             f"(Get-Location).Path | Out-File -Encoding utf8 -FilePath '{quoted_cwd_file}'",
             # Emit CWD marker
             f"$cwd = (Get-Location).Path",
             f"Write-Output ''",
-            f"Write-Output '{marker}' + $cwd + '{marker}'",
+            f"Write-Output ('{marker}' + $cwd + '{marker}')",
             # Exit with captured code
             f"exit $hermes_ec",
         ]


### PR DESCRIPTION
## 变更内容

修复 Windows PowerShell 本地终端 wrapper 在执行对象输出命令后立刻退出时丢失 stdout 的问题。现在 `Invoke-Expression` 的结果会显式进入 `Out-Default`，确保 `Get-Location`、`pwd`、`Test-Path` 等 PowerShell 对象输出在 wrapper 退出前完成格式化。

同时修正 cwd marker 的 PowerShell 字符串拼接，并新增回归测试覆盖 `Get-Location; Test-Path -LiteralPath .` 场景。

## 修复原因

截图中的诊断命令并不是业务命令失败，而是 PowerShell wrapper 吞掉了对象输出，导致终端工具返回空输出，模型误判为路径或执行环境不可用。

## 验证

- `scripts/run_tests.sh tests/tools/test_local_env_windows_msys.py tests/tools/test_shell_resolution.py tests/tools/test_windows_native_support.py tests/tools/test_terminal_task_cwd.py`
- `scripts/run_tests.sh tests/tools/test_terminal_tool.py tests/tools/test_base_environment.py`
- `python -m py_compile tools/environments/local.py tests/tools/test_local_env_windows_msys.py`
- `git diff --check`