### PR TITLE
[codex] 避免 OAuth 状态探测阻塞本地接口

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4084,6 +4084,28 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
     return {"logged_in": False}
 
 
+def _list_oauth_providers_sync() -> Dict[str, Any]:
+    """Enumerate OAuth providers without running on the asyncio event loop.
+
+    Some provider status helpers shell out or touch external credential stores.
+    Running them inline inside an async FastAPI handler blocks uvicorn's event
+    loop and can make unrelated local endpoints, such as `/api/cron/jobs`, wait
+    for several seconds behind OAuth status probing.
+    """
+    providers = []
+    for p in _OAUTH_PROVIDER_CATALOG:
+        status = _resolve_provider_status(p["id"], p.get("status_fn"))
+        providers.append({
+            "id": p["id"],
+            "name": p["name"],
+            "flow": p["flow"],
+            "cli_command": p["cli_command"],
+            "docs_url": p["docs_url"],
+            "status": status,
+        })
+    return {"providers": providers}
+
+
 @app.get("/api/providers/oauth")
 async def list_oauth_providers():
     """Enumerate every OAuth-capable LLM provider with current status.
@@ -4102,18 +4124,8 @@ async def list_oauth_providers():
           expires_at       ISO timestamp string or null
           has_refresh_token bool
     """
-    providers = []
-    for p in _OAUTH_PROVIDER_CATALOG:
-        status = _resolve_provider_status(p["id"], p.get("status_fn"))
-        providers.append({
-            "id": p["id"],
-            "name": p["name"],
-            "flow": p["flow"],
-            "cli_command": p["cli_command"],
-            "docs_url": p["docs_url"],
-            "status": status,
-        })
-    return {"providers": providers}
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, _list_oauth_providers_sync)
 
 
 @app.delete("/api/providers/oauth/{provider_id}")


### PR DESCRIPTION
## 变更说明

这次修复 `/api/providers/oauth` 在 async FastAPI handler 中同步枚举 OAuth provider 状态的问题。部分 provider 状态探测会访问凭据或执行阻塞操作，之前会阻塞 uvicorn event loop，导致本地无关接口，例如 `/api/cron/jobs`，在 OAuth 状态查询期间排队等待数秒。

现在 OAuth provider 状态枚举被放入 executor 线程执行，OAuth 查询本身可能仍需要几秒，但不会再拖慢定时任务等本地 API。

## 验证

- `python3 -m py_compile hermes_cli/web_server.py`
- `git diff --check`
- 本地 9119 并发验证：`cron-during-oauth` 从约 6.7 秒降到约 25 毫秒，`/api/providers/oauth` 自身耗时约 7 秒但不再阻塞其它请求。
