### PR TITLE
[CN-fork] P-002: 恢复被 v0.17.0 同步丢失的 POST /api/upload（修复桌面端粘贴图片 HTTP 405）

### DIFF
--- a/FORK_NOTES.md
+++ b/FORK_NOTES.md
@@ -117,7 +117,9 @@ These are fork maintenance changes, not runtime behavior patches:
 
 **Root cause**: Upstream `e7c3cd772` (commit "Add dashboard attachment upload endpoint") added this endpoint, then it was reverted in a later commit. The endpoint itself is small and self-contained — we just bring it back.
 
-**What the patch does**: Adds a single FastAPI handler that takes a multipart `file` + `session_id`, writes it under `~/.hermes/sessions/<id>/attachments/`, and returns `{ok, filename, path, size, mime_type}`. Reuses upstream's `_next_unique_path` helper for naming collisions.
+**What the patch does**: Adds a single FastAPI handler that takes a multipart `file` + `session_id`, writes it under `~/.hermes/uploads/<session_id>/`, and returns `{ok, filename, path, size, mime_type}`. Uses `_unique_upload_path` for naming collisions and the in-house `_parse_multipart_form` parser (so `python-multipart` is not required at import time).
+
+**Regression — dropped by the v0.17.0 upstream sync (restored, see issue #306)**: a sync silently removed the `@app.post("/api/upload")` handler while leaving its helpers (`_parse_multipart_form` / `_safe_upload_filename` / `_unique_upload_path`) behind as dead code. With the route gone, the SPA catch-all matched the path on GET only, so the desktop composer's POST returned **HTTP 405 Method Not Allowed** and pasting/dropping an image failed (CLI `/paste` was unaffected — it never hits this route). Guarded now by `tests/hermes_cli/test_web_server_upload.py`, which fails if the route disappears again.
 
 **Side effects**: Adds an attachment-upload attack surface. Mitigated by:
 - Gated by the same session token as all other `/api/` routes

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1565,6 +1565,71 @@ def _decode_data_url(data_url: str) -> tuple[bytes, str]:
     return data, mime_type
 
 
+@app.post("/api/upload")
+async def upload_attachment(request: Request):
+    """Store a browser-selected attachment for the local dashboard UI.
+
+    Files are written under ``~/.hermes/uploads/<session_id>/`` and the
+    absolute path is returned so the TUI gateway can attach images or reference
+    files in a follow-up prompt.
+
+    [CN-fork] P-002 — downstream-only; upstream added it once (``e7c3cd772``)
+    then reverted. The desktop composer's paste/drop image flow depends on this
+    route (Desktop ``web/src/lib/transport.ts`` POSTs multipart here, and
+    ``src/commands/api_proxy.rs``'s ``upload_file`` proxies to it). Without it
+    the SPA catch-all answers the path on GET only, so the POST returns HTTP 405
+    and pasting an image fails. Keep this handler beside its helpers and the
+    regression test in ``tests/hermes_cli/test_web_server_upload.py`` so an
+    upstream sync can't silently drop it again. See FORK_NOTES.md P-002.
+    """
+    length_raw = request.headers.get("content-length")
+    try:
+        if length_raw and int(length_raw) > _UPLOAD_MAX_BYTES:
+            raise HTTPException(status_code=413, detail="File too large")
+    except ValueError:
+        pass
+
+    body = await request.body()
+    if len(body) > _UPLOAD_MAX_BYTES:
+        raise HTTPException(status_code=413, detail="File too large")
+
+    try:
+        fields, files = _parse_multipart_form(request.headers.get("content-type", ""), body)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    session_id = (fields.get("session_id") or "default").strip()
+    if not _UPLOAD_SESSION_RE.match(session_id):
+        raise HTTPException(status_code=400, detail="Invalid session id")
+
+    upload = files.get("file")
+    if not upload:
+        raise HTTPException(status_code=400, detail="Missing file")
+
+    content = upload["content"]
+    if not content:
+        raise HTTPException(status_code=400, detail="Empty file")
+
+    upload_dir = get_hermes_home() / "uploads" / session_id
+    upload_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = _safe_upload_filename(str(upload.get("filename") or "attachment"))
+    target = _unique_upload_path(upload_dir, filename)
+    target.write_bytes(content)
+
+    content_type = str(upload.get("content_type") or "")
+    if not content_type or content_type == "application/octet-stream":
+        content_type = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+
+    return {
+        "ok": True,
+        "filename": target.name,
+        "path": str(target),
+        "size": len(content),
+        "mime_type": content_type,
+    }
+
+
 @app.get("/api/files")
 async def list_managed_files(request: Request, path: Optional[str] = None):
     policy, target, display_path = _resolve_managed_path(path, request)

--- a/tests/hermes_cli/test_web_server_upload.py
+++ b/tests/hermes_cli/test_web_server_upload.py
@@ -1,0 +1,106 @@
+"""Regression tests for the dashboard attachment upload route.
+
+[CN-fork] P-002 — ``POST /api/upload`` is a downstream-only endpoint the
+desktop composer depends on for pasting/dropping images. It has been silently
+dropped by an upstream sync before (the handler vanished while its helpers
+``_parse_multipart_form`` / ``_safe_upload_filename`` / ``_unique_upload_path``
+stayed behind as dead code), which made the desktop GUI's Ctrl+V image paste
+fail with ``HTTP 405 Method Not Allowed`` — the SPA catch-all answers the path
+on GET only, so a POST falls through to 405. See Desktop issue #306.
+
+These tests fail loudly if the route disappears again.
+"""
+
+from starlette.testclient import TestClient
+
+from hermes_cli import web_server
+
+
+def _client_with_app_state():
+    prev_auth_required = getattr(web_server.app.state, "auth_required", None)
+    prev_bound_host = getattr(web_server.app.state, "bound_host", None)
+    web_server.app.state.auth_required = False
+    web_server.app.state.bound_host = None
+
+    client = TestClient(web_server.app)
+    client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    return client, prev_auth_required, prev_bound_host
+
+
+def _restore_app_state(prev_auth_required, prev_bound_host):
+    if prev_auth_required is None:
+        delattr(web_server.app.state, "auth_required")
+    else:
+        web_server.app.state.auth_required = prev_auth_required
+    if prev_bound_host is None:
+        if hasattr(web_server.app.state, "bound_host"):
+            delattr(web_server.app.state, "bound_host")
+    else:
+        web_server.app.state.bound_host = prev_bound_host
+
+
+def _upload_client(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.delenv("HERMES_DASHBOARD_FILES_ROOT", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    client, prev_auth_required, prev_bound_host = _client_with_app_state()
+    return client, home, prev_auth_required, prev_bound_host
+
+
+def test_post_api_upload_route_exists_and_accepts_post(monkeypatch, tmp_path):
+    """The core regression: POST /api/upload must be routed to the handler,
+    never fall through to the SPA catch-all and answer 405 (issue #306)."""
+    client, _home, prev_auth, prev_host = _upload_client(monkeypatch, tmp_path)
+    try:
+        resp = client.post(
+            "/api/upload",
+            data={"session_id": "sess-1"},
+            files={"file": ("shot.png", b"\x89PNG\r\n\x1a\n", "image/png")},
+        )
+        assert resp.status_code != 405, "POST /api/upload regressed to 405 — the P-002 route was dropped"
+        assert resp.status_code == 200, resp.text
+    finally:
+        client.close()
+        _restore_app_state(prev_auth, prev_host)
+
+
+def test_upload_writes_file_and_returns_expected_shape(monkeypatch, tmp_path):
+    """The desktop's AttachmentUploadResult schema requires filename/path/size
+    and reads back the absolute path; assert the response shape stays stable."""
+    client, home, prev_auth, prev_host = _upload_client(monkeypatch, tmp_path)
+    try:
+        payload = b"\x89PNG\r\n\x1a\nclipboard-bytes"
+        resp = client.post(
+            "/api/upload",
+            data={"session_id": "abc_123"},
+            files={"file": ("clipboard.png", payload, "image/png")},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["filename"] == "clipboard.png"
+        assert body["size"] == len(payload)
+        assert body["mime_type"] == "image/png"
+
+        written = home / "uploads" / "abc_123" / "clipboard.png"
+        assert written.read_bytes() == payload
+        assert body["path"] == str(written)
+    finally:
+        client.close()
+        _restore_app_state(prev_auth, prev_host)
+
+
+def test_upload_rejects_invalid_session_id(monkeypatch, tmp_path):
+    client, _home, prev_auth, prev_host = _upload_client(monkeypatch, tmp_path)
+    try:
+        resp = client.post(
+            "/api/upload",
+            data={"session_id": "../escape"},
+            files={"file": ("x.png", b"data", "image/png")},
+        )
+        assert resp.status_code == 400
+    finally:
+        client.close()
+        _restore_app_state(prev_auth, prev_host)


### PR DESCRIPTION
## 问题

桌面版 GUI 聊天框 Ctrl+V 粘贴图片报 **HTTP 405 Method Not Allowed**（Desktop issue #306，Windows 端稳定复现，用户反馈集中）。CLI `/paste` 正常 → 后端配置与视觉模型无问题，只是 GUI 上传链路命中的后端路由出错。

## 根因

`v0.17.0 上游同步` 静默删掉了 fork 专属的 `@app.post("/api/upload")` handler（P-002），却把它的辅助函数（`_parse_multipart_form` / `_safe_upload_filename` / `_unique_upload_path`）作为**孤儿死代码**留了下来。路由消失后：

- Dashboard SPA 的 catch-all 只在 **GET** 上匹配该路径，于是桌面端 composer 的 multipart **POST 落到 405**——这正是 405（而非 404）、且后端无错误日志的原因；
- Desktop（`web/src/lib/transport.ts` POST、`src/commands/api_proxy.rs` 的 `upload_file` 代理）依赖此路由；
- Desktop 还把该路由是否出现在 `openapi.json` 当作"后端是不是 fork 版"的兼容性判据（`dashboard.rs`），删了也一并误判。

## 改动（Core 单仓，Desktop 无需改）

- 恢复 `@app.post("/api/upload")` handler，紧挨它的辅助函数放置；docstring 指向 FORK_NOTES P-002，去掉原先指向不存在 `v2/` 路径的过时说明。
- 新增 `tests/hermes_cli/test_web_server_upload.py`：断言 POST 不再 405、上传落盘、返回 `{ok,filename,path,size,mime_type}`、非法 session_id 被拒——**路由再被同步丢掉就会红**。
- 修正 FORK_NOTES P-002 描述以匹配真实代码（`uploads/<session_id>/` + `_unique_upload_path`），并记录这次事故。

## 验证

- `scripts/run_tests.sh tests/hermes_cli/test_web_server_upload.py` → 3 passed
- `ruff check` → All checks passed

> 注：桌面端用户需等带本修复的新 runtime 内核发布后才能生效。

Fixes Eynzof/Hermes-CN-Desktop#306

🤖 Generated with [Claude Code](https://claude.com/claude-code)