### PR TITLE
fix(gateway): 让桌面端重启网关按钮真正生效（剥离 spawn 子进程的 _HERMES_GATEWAY 标记）

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2446,12 +2446,29 @@ def _spawn_hermes_action(
 
     cmd = [sys.executable, "-m", "hermes_cli.main", *subcommand]
 
+    # A detached ``hermes <subcommand>`` child is a fresh, external CLI
+    # invocation — never the running gateway itself. ``gateway/run.py`` sets
+    # ``_HERMES_GATEWAY=1`` as a *module-level* import side effect, so a process
+    # that has imported it leaks the marker into this child's environment. On the
+    # desktop's managed runtime the dashboard is served from inside the gateway
+    # process, so ``hermes gateway restart`` spawned here would inherit the marker
+    # and the restart guard would misfire — "Refusing to restart the gateway from
+    # inside the gateway process" — making the desktop's restart button a no-op
+    # (issue Eynzof/Hermes-CN-Desktop#224). Strip the marker so this child is the
+    # "external shell" the guard expects. The agent-tool-call restart path runs
+    # ``hermes gateway restart`` directly (not via this helper), so its loop
+    # protection is unaffected.
+    child_env = {k: v for k, v in os.environ.items() if k != "_HERMES_GATEWAY"}
+    child_env["HERMES_NONINTERACTIVE"] = "1"
+    if extra_env:
+        child_env.update(extra_env)
+
     popen_kwargs: Dict[str, Any] = {
         "cwd": str(PROJECT_ROOT),
         "stdin": subprocess.DEVNULL,
         "stdout": log_file,
         "stderr": subprocess.STDOUT,
-        "env": {**os.environ, "HERMES_NONINTERACTIVE": "1", **(extra_env or {})},
+        "env": child_env,
     }
     if sys.platform == "win32":
         popen_kwargs["creationflags"] = (

--- a/tests/hermes_cli/test_web_server_gateway_restart_env.py
+++ b/tests/hermes_cli/test_web_server_gateway_restart_env.py
@@ -1,0 +1,60 @@
+"""Regression test for the desktop gateway-restart button (issue #224).
+
+``gateway/run.py`` sets ``_HERMES_GATEWAY=1`` as a module-level import side
+effect. On the desktop's managed runtime the dashboard is served from inside the
+gateway process, so a ``hermes gateway restart`` spawned by the dashboard via
+``_spawn_hermes_action`` used to inherit that marker and trip the gateway CLI's
+"Refusing to restart the gateway from inside the gateway process" guard — the
+restart button did nothing. The spawn helper must strip ``_HERMES_GATEWAY`` so
+the detached child is the "external shell" the guard expects.
+"""
+
+import subprocess
+
+from hermes_cli import web_server
+
+
+class _FakePopen:
+    def __init__(self, cmd, **kwargs):
+        self.cmd = cmd
+        self.kwargs = kwargs
+        self.pid = 4321
+
+    def poll(self):
+        return None
+
+
+def _spawn_capture(monkeypatch, tmp_path, *, extra_env=None):
+    captured = {}
+
+    def _fake_popen(cmd, **kwargs):
+        proc = _FakePopen(cmd, **kwargs)
+        captured["env"] = kwargs.get("env")
+        return proc
+
+    monkeypatch.setattr(subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(web_server, "_ACTION_LOG_DIR", tmp_path)
+    # Mark this (test) process as if it were running inside the gateway.
+    monkeypatch.setenv("_HERMES_GATEWAY", "1")
+
+    web_server._spawn_hermes_action(
+        ["gateway", "restart"], "gateway-restart", extra_env=extra_env
+    )
+    return captured["env"]
+
+
+def test_spawned_action_strips_gateway_marker(monkeypatch, tmp_path):
+    env = _spawn_capture(monkeypatch, tmp_path)
+    # The child must NOT look like the running gateway, or the restart guard fires.
+    assert "_HERMES_GATEWAY" not in env
+    # Other expected env is still present.
+    assert env["HERMES_NONINTERACTIVE"] == "1"
+
+
+def test_extra_env_still_applied_without_marker(monkeypatch, tmp_path):
+    env = _spawn_capture(
+        monkeypatch, tmp_path, extra_env={"HERMES_GATEWAY_FORCE_TAKEOVER": "1"}
+    )
+    assert "_HERMES_GATEWAY" not in env
+    assert env["HERMES_GATEWAY_FORCE_TAKEOVER"] == "1"
+    assert env["HERMES_NONINTERACTIVE"] == "1"


### PR DESCRIPTION
关联 Desktop issue: Eynzof/Hermes-CN-Desktop#224

## 问题

桌面端左下角"重启网关"按钮点了没反应、显示失败；dashboard(:9120) 日志里是：
```
✗ Refusing to restart the gateway from inside the gateway process.
This command was blocked to prevent restart loops.
Use `hermes gateway restart` from a shell outside the running gateway.
```

## 根因

`gateway/run.py:1213` 把 `os.environ["_HERMES_GATEWAY"] = "1"` 设在**模块级**（import 副作用）。桌面端托管运行时里，**dashboard 是由网关进程内部提供服务的**（同进程既是网关又服务 :9120），所以该进程 import 了 `gateway.run` 后就带上了这个标记。点重启时，`_spawn_hermes_action` spawn 出的 `hermes gateway restart` 子进程**继承**了这个标记 → 触发 `hermes_cli/gateway.py` 的防循环守卫（`os.getenv("_HERMES_GATEWAY")=="1"` → 拒绝）→ exit 1。守卫语义上没错（确实从网关进程内发起），但桌面端这就是正常拓扑、用户根本没有"外部 shell"。

## 修复

`_spawn_hermes_action` spawn 的是**全新的外部 `hermes` CLI 子进程**，本就不该带"我是运行中的网关"这个标记。构造子进程 env 时剥离 `_HERMES_GATEWAY`，让它成为守卫所说的"外部 shell"。

**不影响**对 agent 工具调用循环重启的防护——那条路径是 agent 直接在网关进程内跑 `hermes gateway restart`，不经过本 helper。

## 验证

- 新增 `tests/hermes_cli/test_web_server_gateway_restart_env.py`（断言 spawn 子进程 env 不含 `_HERMES_GATEWAY`、`extra_env` 仍生效）→ 2 passed
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py` → 307 passed
- `ruff check` → All checks passed

> ⚠️ 后端修复：桌面端需装上带此修复的新 runtime 内核后生效。

Fixes Eynzof/Hermes-CN-Desktop#224

🤖 Generated with [Claude Code](https://claude.com/claude-code)