### PR TITLE
[CN-fork] P-004: remove dead /api/fs/list home-restriction helpers

### DIFF
--- a/FORK_NOTES.md
+++ b/FORK_NOTES.md
@@ -9,7 +9,7 @@ This document explains the fork-specific changes on `main` that diverge from ups
 | **P-025** | `hermes_cli/web_server.py` | `/api/providers/oauth` now (1) serves from a 20s per-profile in-process TTL cache, (2) runs each provider's status check concurrently via `asyncio.to_thread` (OFF the FastAPI event loop) instead of serially inline, and (3) busts the cache on every connect/disconnect (disconnect clear paths, PKCE submit, device-code/loopback poll→`approved`). Adds a `refresh=true` escape hatch. | The desktop Models page enumerated every OAuth provider's status serially on every open AND every window refocus; some checks touch the network/subprocess, and because the handler is `async` they blocked the event loop that also serves the chat gateway WebSocket — so 模型页 took seconds to open and could stutter live chat. | Should be upstreamed (generic responsiveness fix) |
 | **P-002** | `hermes_cli/web_server.py` | Adds `POST /api/upload` for dashboard attachment uploads | v2 web composer's drag-to-upload depends on it; upstream had it once (`e7c3cd772`) then reverted | Not in upstream |
 | **P-003** | `hermes_cli/web_server.py` | Drops the `_DASHBOARD_EMBEDDED_CHAT_ENABLED` gate on `/api/ws` | v2 runs `hermes dashboard` without `--tui`, the gate would close gateway WS | **Largely addressed upstream** — v0.16.0 (#38591) defaults the flag to `True` and removes the dashboard `--tui` flag; fork keeps the explicit gate removal on `/api/ws` as defense-in-depth |
-| **P-004** | `hermes_cli/web_server.py` | Adds `GET /api/fs/list` for the v2 web workspace picker | v2 `/new` task page browses directories instead of `window.prompt()` for path; restricted to user home subtree | Not in upstream |
+| **P-004** | `hermes_cli/web_server.py` | Originally added `GET /api/fs/list` for the v2 web workspace picker | Upstream later shipped its own `/api/fs/list`; fork helpers removed, route now matches upstream (no home restriction) | Converged upstream |
 | **P-005** | `hermes_cli/web_server.py` | Adds `GET /api/mcp-servers` (read-only `{summary, servers:[{name,enabled}]}`) — handler `list_mcp_servers_summary` | v2 panel "健康检查" cell needs MCP count without leaking command/args/env (which embed secrets) | Distinct from upstream's `/api/mcp/servers` (exposes url/command/args); fork handler renamed in 2026-06-04 sync to avoid an operationId clash |
 | **P-006** | `hermes_cli/config.py` | Registers `OPTIONAL_ENV_VARS` for CN providers (ARK / QIANFAN / HUNYUAN / SILICONFLOW / MODELSCOPE / AI302 / COMPSHARE) | Dashboard env panel is metadata-driven; upstream only knows global providers (OpenAI / Anthropic / Google / DeepSeek) | Won't be upstreamed (CN-specific) |
 | ~~**P-007**~~ | `tui_gateway/ws.py` | ~~Wraps the dispatch handler in a try/except that logs traceback + returns a JSON-RPC error response instead of silently closing the WS~~ | Without this, any unhandled handler exception or json.dumps serialization failure shows up in the client as "WebSocket closed" with zero diagnostic context | **Superseded by upstream** — dropped in 2026-06-04 sync |
@@ -163,22 +163,18 @@ These are fork maintenance changes, not runtime behavior patches:
 
 **Symptom**: v2 `/new` task page → "选择 workspace" → falls back to `window.prompt()` asking the user to type a path. UX is bad on a desktop OS.
 
-**Root cause**: Upstream has no filesystem browse endpoint. Electron desktop shells use the OS native dialog, but a pure web UI can't.
+**Root cause**: Upstream (at the time) had no filesystem browse endpoint. Electron desktop shells use the OS native dialog, but a pure web UI can't.
 
-**What the patch does**: Adds `GET /api/fs/list?path=<dir>&include_hidden=<bool>` returning `{path, parent, home, entries: [{name, path, is_dir}]}`. Path is resolved through:
-- `~` expansion
-- `..` folding via `Path.resolve(strict=False)`
-- enforced subtree of `Path.home()` (raises 400 if outside)
+**Original patch**: Added `GET /api/fs/list?path=<dir>&include_hidden=<bool>` returning `{path, parent, home, entries: [{name, path, is_dir}]}`, resolved via `~` expansion, `..` folding, and an enforced `Path.home()` subtree (400 if outside), plus a 5000-entry cap. Fork helpers: `_resolve_fs_path`, `_list_directory_entries`, `_FS_LIST_MAX_ENTRIES`.
 
-Plus a 5000-entry cap to bound responses on huge directories.
+**Update (2026-06 — converged with upstream)**: Upstream subsequently shipped its own `/api/fs/list` (`fs_list` → `_fs_path`), which replaced the fork handler during a sync. The route now IS upstream's: it returns `{entries: [{name, path, isDirectory}]}` (camelCase, **no** top-level `path`/`parent`/`home`) and on permission/IO errors returns **HTTP 200** with `{entries: [], error: "EACCES"|"ENOENT"|...}`. `_fs_path` only rejects null bytes / unparseable paths and resolves relative paths against cwd — there is **no home-subtree restriction** anymore.
+- The original fork helpers (`_resolve_fs_path`, `_list_directory_entries`, `_FS_LIST_MAX_ENTRIES`) were orphaned by that sync and have now been **removed** as dead code.
+- The home restriction was intentionally **not** restored: desktop session workspaces are legitimately arbitrary (outside `$HOME`, other drives, containers), so a hard home cap would break them. The Desktop's Rust `read_workspace_file` command already confines file *reads* to the session workspace root.
+- Desktop consumers were realigned to this shape in Hermes-CN-Desktop PR #330 (tolerant Zod parser; the old required `path`/`parent`/`home`/`is_dir` had been breaking the file browser for every user).
 
-**Side effects**: Adds a directory-listing attack surface. Mitigated by:
-- Token gate (same as all `/api/` routes)
-- Enforced home subtree — picker can't wander into `/Library`, `/private`, `/System`, etc.
-- Permissions tolerant — entries that fail `is_dir()` (broken symlinks, denied access) are silently skipped
-- Hidden-file filter defaults to off
+**Side effects**: Directory-listing attack surface, mitigated by the token gate on all `/api/` routes (local, loopback-bound). No home restriction — acceptable for a local desktop runtime.
 
-**Should we upstream?** Maybe — depends on whether upstream wants browser-only Web UI to be a first-class deployment target.
+**Should we upstream?** N/A — already converged with upstream.
 
 ---
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -425,67 +425,6 @@ def _unique_upload_path(directory: Path, filename: str) -> Path:
     raise ValueError("too many files with the same name")
 
 
-_FS_LIST_MAX_ENTRIES = 5000  # safety cap; /tmp or huge dirs would otherwise return tens of thousands of entries
-
-
-def _resolve_fs_path(raw: str) -> Path:
-    """Resolve a user-supplied path for /api/fs/list (P-004).
-
-    P-004 helper: empty / missing → home; ~ expansion; .. folded via .resolve().
-    Restricted to the user home subtree — anything outside raises 400 so the
-    web picker cannot wander into /Library, /private, /System etc. (most of
-    which are TCC-blocked anyway and would 403 the whole listing).
-    """
-    home = Path.home().resolve(strict=False)
-    candidate = (raw or "").strip()
-    if not candidate:
-        return home
-    if candidate.startswith("~"):
-        path = Path(candidate).expanduser().resolve(strict=False)
-    else:
-        path = Path(candidate).resolve(strict=False)
-    try:
-        path.relative_to(home)
-    except ValueError:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Path must be inside your home directory ({home})",
-        )
-    return path
-
-
-def _list_directory_entries(directory: Path, include_hidden: bool) -> List[Dict[str, Any]]:
-    """List immediate children of a directory for /api/fs/list (P-004).
-
-    Returns dicts with name/path/is_dir.  Skips entries whose stat fails (broken
-    symlinks, permission errors).  Sorted: directories first, then case-insensitive name.
-    Capped at _FS_LIST_MAX_ENTRIES to keep responses bounded.
-    """
-    entries: List[Dict[str, Any]] = []
-    try:
-        with os.scandir(directory) as scanner:
-            for entry in scanner:
-                if not include_hidden and entry.name.startswith("."):
-                    continue
-                try:
-                    is_dir = entry.is_dir(follow_symlinks=False)
-                except OSError:
-                    continue
-                entries.append({
-                    "name": entry.name,
-                    "path": str(directory / entry.name),
-                    "is_dir": is_dir,
-                })
-                if len(entries) >= _FS_LIST_MAX_ENTRIES:
-                    break
-    except PermissionError:
-        raise HTTPException(status_code=403, detail="Permission denied")
-    except OSError as exc:
-        raise HTTPException(status_code=500, detail=f"Failed to read directory: {exc}")
-    entries.sort(key=lambda e: (not e["is_dir"], e["name"].lower()))
-    return entries
-
-
 # Accepted Host header values for loopback binds. DNS rebinding attacks
 # point a victim browser at an attacker-controlled hostname (evil.test)
 # which resolves to 127.0.0.1 after a TTL flip — bypassing same-origin


### PR DESCRIPTION
## Why

An upstream sync replaced the fork's original `/api/fs/list` handler with upstream's `fs_list` (→ `_fs_path`). That left three fork-only helpers **orphaned with zero callers**:

- `_resolve_fs_path` — the old `Path.home()` subtree restriction
- `_list_directory_entries`
- `_FS_LIST_MAX_ENTRIES`

This PR removes them as dead code and updates **FORK_NOTES P-004** to record the convergence.

## Context

This is the Core-side follow-up to **Hermes-CN-Desktop #330**. That bug: the route now returns upstream's shape (`{entries:[{name,path,isDirectory}]}`, HTTP-200 `{error}` on EACCES/ENOENT, no `path`/`parent`/`home`), but the desktop's Zod parser still required the old fork shape, so the file browser threw for **every** directory on Win + Mac. #330 made the desktop parser tolerant; this PR cleans up the now-dead Core helpers.

## Note on the home restriction

The `Path.home()` subtree restriction is **intentionally not restored**: desktop session workspaces are legitimately arbitrary (outside `$HOME`, other drives, containers), so a hard home cap would break them. File *reads* are already confined to the session workspace root by the desktop's Rust `read_workspace_file` command. The route stays loopback-bound and token-gated like all `/api/` routes.

## Verification

- `ruff check hermes_cli/web_server.py` ✅ (no callers remain; no newly-unused imports)
- `pytest tests/hermes_cli/test_web_server_fs.py` ✅ (13 passed)
- Pure deletion + docs; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)