### PR TITLE
test: de-flake timing-sensitive tests in tests/tools/ (pwsh wrapper + sigkill tree)

### DIFF
--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -162,11 +162,17 @@ class TestPowerShellWrapperOutput:
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
         monkeypatch.setattr(local_mod, "_resolve_shell", lambda: ("powershell", shell))
 
-        env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+        # Generous timeout: this is the only test here that spawns a REAL
+        # PowerShell subprocess. pwsh/powershell.exe cold-start can exceed 10s
+        # on a loaded CI runner (8 parallel workers), which previously made
+        # this test flaky with returncode 124 (timeout). The command itself is
+        # trivial — we're asserting output formatting, not latency — so a large
+        # ceiling removes the flake while still catching a genuinely hung shell.
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=60)
         try:
             result = env.execute(
                 "Get-Location; Test-Path -LiteralPath .",
-                timeout=10,
+                timeout=60,
             )
         finally:
             env.cleanup()

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1589,7 +1589,13 @@ class TestSigkillEscalation:
                     for p in all_pids
                 )
 
-            assert _wait_until(_all_dead, timeout=4.0), (
+            # Generous wait: after the 1s term-grace the registry escalates to
+            # SIGKILL, but reaping a 3-process tree (parent + 2 children) and
+            # re-probing via psutil can exceed 4s on a loaded CI runner (8
+            # parallel workers) — which made this flake. We assert the tree is
+            # ALL killed, not how fast, so a larger ceiling removes the flake
+            # while still bounding a genuine escalation failure.
+            assert _wait_until(_all_dead, timeout=10.0), (
                 "entire SIGTERM-ignoring tree (parent + children) must be SIGKILLed"
             )
         finally:


### PR DESCRIPTION
## What

De-flakes two timing-sensitive tests under `tests/tools/` that spawn real subprocesses and flake on the loaded CI runner (8 parallel workers, larger suite after the upstream sync). Both assert *behaviour*, not latency, so the fix is just a generous timeout ceiling.

1. **`test_local_env_windows_msys.py::test_object_output_survives_wrapper_exit`** — spawns a real PowerShell subprocess with a 10s timeout. `pwsh`/`powershell.exe` cold-start can exceed 10s under load → `returncode 124`. **10s → 60s.** (Flaked on the P-028 PR #60.)
2. **`test_process_registry.py::test_entire_tree_is_sigkilled_not_just_parent`** — waits 4s for a SIGTERM-ignoring parent+2-children tree to be reaped after the 1s kill-grace; reaping + psutil re-probe can exceed 4s under load. **4s → 10s.** (Flaked on this PR's CI, slice 4/8.)

Neither is a logic bug (both pass on re-run / locally) — purely test robustness. Both are generic and upstreamable.

## Verification

Locally: pwsh test skips as designed on Linux (file green, `10 passed, 1 skipped`); sigkill test passes 3× at ~2s; `ruff` clean. The real timing paths exercise on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
