### PR TITLE
fix(desktop): make toChatMessages O(N) by indexing tool-call parts (#19)

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -785,3 +785,101 @@ describe('upsertToolPart', () => {
     })
   })
 })
+
+describe('toChatMessages stored-tool-result resolution (issue #19 O(N^2) → O(N))', () => {
+  type ToolCallPart = Extract<ChatMessagePart, { type: 'tool-call' }>
+
+  const toolParts = (messages: ChatMessage[]): ToolCallPart[] =>
+    messages.flatMap(m => m.parts.filter((p): p is ToolCallPart => p.type === 'tool-call'))
+
+  const resultFor = (messages: ChatMessage[], toolCallId: string): unknown =>
+    toolParts(messages).find(p => p.toolCallId === toolCallId)?.result
+
+  it('resolves tool results to the matching tool-call by id even when rows arrive out of order', () => {
+    const messages = toChatMessages([
+      { role: 'user', content: 'go', timestamp: 1 },
+      {
+        role: 'assistant',
+        content: 'first',
+        timestamp: 2,
+        tool_calls: [{ id: 'tc-1', function: { name: 'terminal', arguments: '{}' } }]
+      },
+      {
+        role: 'assistant',
+        content: 'second',
+        timestamp: 3,
+        tool_calls: [{ id: 'tc-2', function: { name: 'terminal', arguments: '{}' } }]
+      },
+      // results arrive in REVERSE order of the calls
+      { role: 'tool', tool_call_id: 'tc-2', tool_name: 'terminal', content: '{"output":"RESULT-2"}', timestamp: 4 },
+      { role: 'tool', tool_call_id: 'tc-1', tool_name: 'terminal', content: '{"output":"RESULT-1"}', timestamp: 5 }
+    ])
+
+    expect(resultFor(messages, 'tc-1')).toMatchObject({ output: 'RESULT-1' })
+    expect(resultFor(messages, 'tc-2')).toMatchObject({ output: 'RESULT-2' })
+  })
+
+  it('disambiguates same-named tools by id, not tool name', () => {
+    const messages = toChatMessages([
+      {
+        role: 'assistant',
+        content: '',
+        timestamp: 1,
+        tool_calls: [
+          { id: 'a', function: { name: 'terminal', arguments: '{"command":"ls"}' } },
+          { id: 'b', function: { name: 'terminal', arguments: '{"command":"pwd"}' } }
+        ]
+      },
+      { role: 'tool', tool_call_id: 'b', tool_name: 'terminal', content: '{"output":"/home"}', timestamp: 2 },
+      { role: 'tool', tool_call_id: 'a', tool_name: 'terminal', content: '{"output":"file.txt"}', timestamp: 3 }
+    ])
+
+    expect(resultFor(messages, 'a')).toMatchObject({ output: 'file.txt' })
+    expect(resultFor(messages, 'b')).toMatchObject({ output: '/home' })
+  })
+
+  it('still resolves a tool row that has no tool_call_id via the tool-name fallback', () => {
+    const messages = toChatMessages([
+      {
+        role: 'assistant',
+        content: 'thinking',
+        timestamp: 1,
+        tool_calls: [{ id: 'only', function: { name: 'web_search', arguments: '{}' } }]
+      },
+      // legacy/orphaned row: no tool_call_id, matched by tool_name
+      { role: 'tool', tool_name: 'web_search', content: '{"summary":"hit"}', timestamp: 2 }
+    ])
+
+    expect(resultFor(messages, 'only')).toMatchObject({ summary: 'hit' })
+  })
+
+  it('attaches every result correctly across many turns (scale guard for the index path)', () => {
+    const N = 40
+    const rows = []
+
+    for (let i = 0; i < N; i += 1) {
+      rows.push({
+        role: 'assistant' as const,
+        content: `step ${i}`,
+        timestamp: i * 2 + 1,
+        tool_calls: [{ id: `tc-${i}`, function: { name: 'terminal', arguments: `{"command":"echo ${i}"}` } }]
+      })
+      rows.push({
+        role: 'tool' as const,
+        tool_call_id: `tc-${i}`,
+        tool_name: 'terminal',
+        content: `{"output":"out-${i}"}`,
+        timestamp: i * 2 + 2
+      })
+    }
+
+    const messages = toChatMessages(rows)
+    const parts = toolParts(messages)
+
+    expect(parts).toHaveLength(N)
+
+    for (let i = 0; i < N; i += 1) {
+      expect(resultFor(messages, `tc-${i}`)).toMatchObject({ output: `out-${i}` })
+    }
+  })
+})

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -574,10 +574,37 @@ function toolPartFromStoredCall(call: unknown, fallbackIndex: number): ChatMessa
   }
 }
 
-function applyStoredToolResult(messages: ChatMessage[], toolMessage: SessionMessage): boolean {
+function applyStoredToolResult(
+  messages: ChatMessage[],
+  toolMessage: SessionMessage,
+  toolCallIndex?: Map<string, { mi: number; pi: number }>
+): boolean {
   const toolCallId = toolMessage.tool_call_id || undefined
   const toolName = toolMessage.tool_name || toolMessage.name || 'tool'
   const content = toolMessage.content || toolMessage.text || toolMessage.context || toolMessage.name
+
+  // Fast O(1) path: tool-call ids are unique, so an index of where each
+  // tool-call part lives in `messages` resolves the result without the reverse
+  // scan below. That scan ran once per tool row over the whole transcript,
+  // making toChatMessages O(N^2) on long sessions (a desktop ANR contributor,
+  // issue #19). Falls through to the scan on a miss, or when the tool row has
+  // no id (legacy/orphaned rows resolved by tool-name) — preserving behavior.
+  if (toolCallId && toolCallIndex) {
+    const loc = toolCallIndex.get(toolCallId)
+
+    if (loc) {
+      const message = messages[loc.mi]
+      const existing = message?.parts[loc.pi]
+
+      if (message?.role === 'assistant' && existing?.type === 'tool-call' && existing.toolCallId === toolCallId) {
+        const parts = [...message.parts]
+        parts[loc.pi] = { ...existing, result: parseStoredToolResult(content), isError: false } as ChatMessagePart
+        messages[loc.mi] = { ...message, parts }
+
+        return true
+      }
+    }
+  }
 
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     const message = messages[i]
@@ -695,6 +722,30 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
   let pendingToolTimestamp: number | undefined
   let activeAssistantIndex: null | number = null
 
+  // Index of where each tool-call part lives in `result`, keyed by its unique
+  // toolCallId, so applyStoredToolResult resolves a stored tool result in O(1)
+  // instead of reverse-scanning the whole transcript per tool row (O(N^2),
+  // issue #19). Updated incrementally as tool-call parts are appended to
+  // `result`; positions are stable because results are filled in place and
+  // parts are only ever appended (never reordered/inserted before existing).
+  const toolCallIndex = new Map<string, { mi: number; pi: number }>()
+
+  const indexToolCallsFrom = (mi: number, fromPartIndex = 0) => {
+    const msg = result[mi]
+
+    if (!msg || msg.role !== 'assistant') {
+      return
+    }
+
+    for (let pi = fromPartIndex; pi < msg.parts.length; pi += 1) {
+      const part = msg.parts[pi]
+
+      if (part.type === 'tool-call' && part.toolCallId) {
+        toolCallIndex.set(part.toolCallId, { mi, pi })
+      }
+    }
+  }
+
   const clearPendingTools = () => {
     pendingToolParts = []
     pendingToolTimestamp = undefined
@@ -713,8 +764,10 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
       return false
     }
 
+    const startIndex = active.parts.length
     active.parts = [...active.parts, ...parts]
     active.timestamp = timestamp ?? active.timestamp
+    indexToolCallsFrom(activeAssistantIndex, startIndex)
 
     return true
   }
@@ -732,6 +785,7 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
         timestamp: pendingToolTimestamp
       })
       activeAssistantIndex = result.length - 1
+      indexToolCallsFrom(activeAssistantIndex, 0)
     }
 
     clearPendingTools()
@@ -747,7 +801,7 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
         return
       }
 
-      if (applyStoredToolResult(result, message)) {
+      if (applyStoredToolResult(result, message, toolCallIndex)) {
         return
       }
 
@@ -815,8 +869,10 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
       const activeHasToolCall = Boolean(activeAssistant?.parts.some(part => part.type === 'tool-call'))
 
       if (activeAssistant && (currentHasToolCall || activeHasToolCall)) {
+        const startIndex = activeAssistant.parts.length
         activeAssistant.parts = [...activeAssistant.parts, ...parts]
         activeAssistant.timestamp = message.timestamp ?? activeAssistant.timestamp
+        indexToolCallsFrom(activeAssistantIndex ?? -1, startIndex)
 
         return
       }
@@ -830,6 +886,7 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
       parts,
       timestamp: message.timestamp
     })
+    indexToolCallsFrom(result.length - 1, 0)
 
     activeAssistantIndex = message.role === 'assistant' ? result.length - 1 : null
   })


### PR DESCRIPTION
## fix(desktop): make `toChatMessages` O(N) by indexing tool-call parts

Partially addresses #19 (Windows desktop ANR/freeze). The four primary ANR causes were already fixed by PR #20; this is one of the remaining follow-up items the issue lists.

### Problem
`applyStoredToolResult()` reverse-scanned the **entire accumulated transcript** (`result`) once per `tool` row to find the assistant tool-call part to fill in — making `toChatMessages` **O(N²)** on long sessions. On a big transcript this is a real main-thread cost when the chat timeline (re)builds, contributing to the renderer freeze in #19.

### Fix
Maintain a `Map<toolCallId, {mi, pi}>` of where each tool-call part lives in `result`, updated incrementally as parts are appended. Positions are stable (results are filled **in place** and parts are only ever **appended**, never reordered/inserted before existing ones), so the index stays valid. Tool-call ids are unique, so the common path is now an **O(1)** lookup.

The original reverse scan is kept as a **fallback** for the rare `tool` row that has no `tool_call_id` (resolved by tool name) — so resolution behavior is unchanged, only faster.

### Tests (`apps/desktop/src/lib/chat-messages.test.ts`)
New cases, all green:
- results arriving **out of order** still attach to the right call by id;
- two same-named tools (`terminal`/`terminal`) **disambiguated by id**, not name;
- a `tool` row with **no `tool_call_id`** still resolves via the tool-name fallback;
- a **40-turn scale guard** asserting every result attaches to its matching call.

All **29 existing `toChatMessages` tests** still pass. `npm run typecheck` (tsc) and `eslint` on the changed files are clean.

### Remaining #19 follow-ups (not in this PR)
Still open, larger renderer-side work: virtualize the command-center session list (`command-center/index.tsx`) and `/skills` list, and chunk/Worker-ize the artifacts-page extraction (`artifacts/index.tsx`). Tracked in #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
