### PR TITLE
Fix Windows console window flash and command execution issues

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8962,9 +8962,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                             # has all API keys in os.environ.
                             from tools.environments.local import _sanitize_subprocess_env
                             sanitized_env = _sanitize_subprocess_env(os.environ.copy())
+                            _subprocess_kwargs = {}
+                            if sys.platform == "win32":
+                                from hermes_cli._subprocess_compat import windows_hide_flags
+                                _subprocess_kwargs["creationflags"] = windows_hide_flags()
                             result = subprocess.run(
                                 exec_cmd, shell=True, capture_output=True,
-                                text=True, timeout=30, env=sanitized_env
+                                text=True, timeout=30, env=sanitized_env, **_subprocess_kwargs
                             )
                             output = result.stdout.strip() or result.stderr.strip()
                             if output:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12961,7 +12961,7 @@ def _resolve_profile_dir(name: str) -> Path:
 def _profile_setup_command(name: str) -> str:
     """Return the shell command used to configure a profile in the CLI."""
     _resolve_profile_dir(name)
-    return "hermes setup" if name == "default" else f"{name} setup"
+    return "hermes setup" if name == "default" else f"hermes setup --profile {name}"
 
 
 def _write_profile_model(profile_dir: Path, provider: str, model: str) -> None:
@@ -13266,13 +13266,13 @@ async def open_profile_terminal_endpoint(name: str):
         command = _profile_setup_command(name)
 
         if sys.platform.startswith("win"):
-            # ``start ""`` — the empty first (quoted) token is the window
-            # title, so the command itself is never mistaken for one.
-            # creationflags suppresses the parent console flash
-            # ([CN-fork] issue #90).
+            # Use list argv to avoid cmd.exe re-tokenization of paths
+            # with spaces. creationflags suppresses parent console flash
+            # ([CN-fork] issue #90, #378).
             from hermes_cli._subprocess_compat import windows_hide_flags
             subprocess.Popen(
-                ["cmd.exe", "/c", "start", "", command],
+                ["cmd.exe", "/c", "start", "Hermes Profile Setup",
+                 "hermes", "setup", "--profile", name],
                 creationflags=windows_hide_flags(),
             )
         elif sys.platform == "darwin":


### PR DESCRIPTION
## What does this PR do?

修复 Desktop #378：Windows 启动后弹出控制台窗口闪退问题。

Root cause: cmd.exe 对含空格路径重新分词 + subprocess 调用缺失 creationflags。

## Related Issue

Fixes #378 (Desktop: Windows console window flashing)

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

### ① `hermes_cli/web_server.py` — open-terminal 端点
- `_profile_setup_command`：非默认 profile 缺 `hermes` 前缀 → 补全
- 改用 list argv `["cmd.exe", "/c", "start", ...]` 避免 cmd.exe 空格拆分

### ② `cli.py` — CLI quick-command exec
- `subprocess.run(shell=True)` 补 `windows_hide_flags()`

### 已验证无需修复
mcp_catalog.py、tui_gateway/server.py、cli_commands_mixin.py、_subprocess_compat.py 均已覆盖 creationflags。全仓扫描零遗漏。

## How to Test

1. Windows 上创建含空格的 profile 名，启动 open-terminal
2. 执行 quick-command exec，确认无控制台窗口弹出
3. `grep shell=True *.py` 确认均含 creationflags

## Checklist

- [x] 遵循 Conventional Commits
- [x] 非重复 PR
- [x] 仅包含相关更改
- [x] 已在 Windows 实测


