### PR TITLE
fix: 补全技能接口来源类型契约

### DIFF
--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4288,6 +4288,39 @@ class TestNewEndpoints:
             },
         ]
 
+    def test_skills_list_reports_canonical_provenance_priority(self, monkeypatch):
+        import tools.skill_usage as skill_usage
+        import tools.skills_tool as skills_tool
+
+        names = ["bundled-skill", "hub-skill", "agent-skill"]
+        monkeypatch.setattr(
+            skills_tool,
+            "_find_all_skills",
+            lambda *, skip_disabled=False: [
+                {"name": name, "description": name, "category": "demo"}
+                for name in names
+            ],
+        )
+        monkeypatch.setattr(
+            skill_usage,
+            "_read_bundled_manifest_names",
+            lambda: {"bundled-skill", "hub-skill"},
+        )
+        monkeypatch.setattr(skill_usage, "_read_hub_installed_names", lambda: {"hub-skill"})
+        monkeypatch.setattr(skill_usage, "load_usage", lambda: {})
+
+        resp = self.client.get("/api/skills")
+
+        assert resp.status_code == 200
+        assert {
+            skill["name"]: skill["provenance"]
+            for skill in resp.json()
+        } == {
+            "bundled-skill": "bundled",
+            "hub-skill": "hub",
+            "agent-skill": "agent",
+        }
+
     def test_toolsets_list(self):
         resp = self.client.get("/api/tools/toolsets")
         assert resp.status_code == 200

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2179,11 +2179,15 @@ export interface AutomationBlueprint {
   appUrl: string;
 }
 
+export type SkillProvenance = "bundled" | "hub" | "agent";
+
 export interface SkillInfo {
   name: string;
   description: string;
-  category: string;
+  category: string | null;
   enabled: boolean;
+  provenance: SkillProvenance;
+  usage: number;
 }
 
 export interface SkillContent {


### PR DESCRIPTION
## 变更

- 补全 Core Web API 的 Skill 来源类型契约：`bundled | hub | agent`
- 对齐 `category` 可空与 `usage` 字段
- 新增来源优先级测试，确认 hub、bundled、agent 的判定顺序

## 原因

桌面端需要以当前连接 Core 的 `/api/skills` 与 `/api/skills/content` 为唯一事实来源，类型契约必须完整保留 `provenance`，避免客户端把自建 Skill 误判为内置 Skill。

## 验证

- `npm run typecheck --workspace web`
- `ruff check .`
- `tests/hermes_cli/test_web_server.py`：368 项通过
- 新增来源优先级用例单独通过
- Core 全量：40,869 通过；24 个 macOS/systemd/并发基线失败，均位于未改动文件，另有 2 个浏览器测试文件超时

配套 Desktop PR：https://github.com/Eynzof/Hermes-CN-Desktop/pull/430
