### PR TITLE
修复 WebSocket 流式事件乱序

### DIFF
--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import threading
 import time
 
@@ -162,3 +163,56 @@ def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
         loop.call_soon_threadsafe(loop.stop)
         thread.join(timeout=2)
         loop.close()
+
+
+def test_ws_coalesced_tokens_cannot_be_overtaken_by_completion():
+    """A timer-flushed token batch and a completion batch may overlap.
+
+    ``send_text`` is an await point, so two independent batch coroutines used
+    to interleave and put message.complete ahead of older message.delta frames.
+    Hold the first send open to make that race deterministic.
+    """
+
+    async def run():
+        sent = []
+        first_send_started = asyncio.Event()
+        release_first_send = asyncio.Event()
+        completion_sent = asyncio.Event()
+
+        class FakeWS:
+            async def send_text(self, line):
+                params = json.loads(line)["params"]
+                event_type = params["type"]
+                label = params.get("text", event_type)
+                if label == "delta-1" and not first_send_started.is_set():
+                    first_send_started.set()
+                    await release_first_send.wait()
+                sent.append(label)
+                if event_type == "message.complete":
+                    completion_sent.set()
+
+        loop = asyncio.get_running_loop()
+        transport = ws_mod.WSTransport(FakeWS(), loop, peer="ordering-test")
+
+        complete = {"params": {"type": "message.complete"}}
+
+        transport.write({"params": {"type": "message.delta", "text": "delta-1"}})
+        transport.write({"params": {"type": "message.delta", "text": "delta-2"}})
+        transport._flush_tokens()
+        await first_send_started.wait()
+
+        transport.write({"params": {"type": "message.delta", "text": "delta-3"}})
+        transport.write(complete)
+        await asyncio.sleep(0)
+        release_first_send.set()
+        await asyncio.wait_for(completion_sent.wait(), timeout=1)
+
+        transport.close()
+        assert sent == [
+            "delta-1",
+            "delta-2",
+            "delta-3",
+            "message.complete",
+        ]
+
+    asyncio.run(run())

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -94,6 +94,12 @@ class WSTransport:
         self._loop = loop
         self._peer = peer
         self._closed = False
+        # Every coroutine that writes to the socket must pass through one
+        # serialized writer. Token coalescing can schedule a timer batch while
+        # a non-streaming frame schedules another batch; without this lock the
+        # two ``send_text`` loops interleave at their await points and a
+        # message.complete frame can overtake older message.delta frames.
+        self._send_lock = asyncio.Lock()
         # Token-coalescing buffer (CF-2). Streamed token frames land here and a
         # short timer flushes the batch. The lock guards the buffer + the
         # "armed" flag against the worker threads that call write(); the timer
@@ -215,32 +221,29 @@ class WSTransport:
         with self._token_lock:
             pending = self._pending_tokens
             self._pending_tokens = []
-        if pending:
-            await self._safe_send_many(pending)
-        await self._safe_send(orjson.dumps(obj).decode('utf-8'))
+        pending.append(orjson.dumps(obj).decode("utf-8"))
+        await self._safe_send_many(pending)
         return not self._closed
 
     async def _safe_send(self, line: str) -> None:
-        try:
-            await self._ws.send_text(line)
-        except Exception as exc:
-            self._closed = True
-            _log.warning(
-                "ws send failed peer=%s error_type=%s error=%s",
-                self._peer, type(exc).__name__, exc,
-            )
+        await self._safe_send_many([line])
 
     async def _safe_send_many(self, lines: list[str]) -> None:
-        """Send a batch of pre-serialized frames in order on the loop thread."""
-        try:
-            for line in lines:
-                await self._ws.send_text(line)
-        except Exception as exc:
-            self._closed = True
-            _log.warning(
-                "ws send failed peer=%s error_type=%s error=%s",
-                self._peer, type(exc).__name__, exc,
-            )
+        """Send one indivisible batch of pre-serialized frames in wire order."""
+        async with self._send_lock:
+            if self._closed:
+                return
+            try:
+                for line in lines:
+                    await self._ws.send_text(line)
+            except Exception as exc:
+                self._closed = True
+                _log.warning(
+                    "ws send failed peer=%s error_type=%s error=%s",
+                    self._peer,
+                    type(exc).__name__,
+                    exc,
+                )
 
     def close(self) -> None:
         self._closed = True


### PR DESCRIPTION
## 根因\n\nWSTransport 的令牌合并定时批次与 message.complete 批次会分别启动发送协程。send_text 是 await 点，两个批次可能交错，导致较新的完成事件越过尚未发送的 message.delta。\n\n## 修复\n\n- 为每个 WebSocket transport 增加串行发送锁\n- 每个预序列化批次在锁内不可分割地写入\n- write_async 将待发送令牌与当前控制帧合成同一批次\n- 增加可确定复现旧竞态的事件顺序单元测试\n\n## 验证\n\n- ruff check tui_gateway/ws.py tests/test_tui_gateway_ws.py\n- scripts/run_tests.sh tests/test_tui_gateway_ws.py：5 项通过\n- 真实 Core + fake model 协议闭环：长流式回复所有 delta 均早于 complete，拼接文本与最终文本完全一致\n- Core 全量：40856 项通过；37 项失败均位于未改动文件，属于当前 macOS 环境的 systemctl 缺失、/tmp 解析、DNS/SSRF 与浏览器探测超时等既有基线问题