### PR TITLE
feat: runtime 签名清单切 schema v3，minAppVersion 纳入签名载荷

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -42,6 +42,10 @@ on:
         default: stable
         type: choice
         options: [stable, beta, canary]
+      min_app_version:
+        description: "Desktop floor (minAppVersion) signed into the v3 manifest; empty = workflow default"
+        required: false
+        default: ""
 
 permissions:
   contents: write  # needed to create the Release + upload assets
@@ -60,6 +64,14 @@ jobs:
       # work without a host Node install. Bump as new 22.x LTS patches ship.
       # See FORK_NOTES P-032.
       NODE_RUNTIME_VERSION: "22.12.0"
+      # Desktop ↔ runtime compatibility floor (minAppVersion) signed into
+      # every schema-v3 manifest. Bump when the runtime starts depending on
+      # newer desktop capabilities; workflow_dispatch can override per run.
+      # History: 0.7.0 = first desktop that accepts v3 manifests (v2/v3 dual
+      # reader + forced-upgrade gate). Do NOT ship v3 manifests to a stable
+      # channel before desktop 0.7.0 has rolled out — older desktops fail the
+      # schema check and stop receiving runtime updates until upgraded.
+      RUNTIME_MIN_APP_VERSION_DEFAULT: "0.7.0"
     strategy:
       fail-fast: false
       matrix:
@@ -118,11 +130,19 @@ jobs:
             exit 1
           fi
 
+          # minAppVersion: dispatch input wins, else the workflow default.
+          # Signed into the v3 manifest, so the signer re-validates format.
+          MIN_APP="${{ github.event.inputs.min_app_version }}"
+          if [[ -z "$MIN_APP" ]]; then
+            MIN_APP="$RUNTIME_MIN_APP_VERSION_DEFAULT"
+          fi
+
           echo "runtime_version=$RUNTIME_VERSION" >> "$GITHUB_OUTPUT"
           echo "kernel_version=$KERNEL_VERSION" >> "$GITHUB_OUTPUT"
           echo "runtime_flavor=$RUNTIME_FLAVOR" >> "$GITHUB_OUTPUT"
           echo "runtime_revision=$RUNTIME_REVISION" >> "$GITHUB_OUTPUT"
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "min_app_version=$MIN_APP" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-python@v5
         with:
@@ -541,6 +561,7 @@ jobs:
             --artifact-path "out/$NAME.zip" \
             --source-repo "${GITHUB_REPOSITORY}" \
             --source-commit "${GITHUB_SHA}" \
+            --min-app-version "${{ steps.meta.outputs.min_app_version }}" \
             --output "out/${{ steps.meta.outputs.channel }}-${{ matrix.platform }}-${{ matrix.arch }}.json"
 
       - name: Upload artifacts

--- a/docs/RUNTIME_RELEASES.md
+++ b/docs/RUNTIME_RELEASES.md
@@ -30,11 +30,13 @@ https://github.com/Eynzof/hermes-agent-cn/releases/download/runtime-v0.14.0-cn.1
 
 The canonical versioning contract is documented in `docs/RUNTIME_VERSIONING.md`.
 The manifest schema (see `src/process/runtime.rs::RuntimeUpdateManifest`
-on the desktop side) is schema v2:
+on the desktop side) is schema v3 — v2 plus a required, signed
+`minAppVersion` (desktop >= 0.7.0 accepts both; `--schema 2` exists for
+transition re-issues to older clients):
 
 ```json
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "channel": "stable",
   "runtimeVersion": "0.14.0-cn.1",
   "kernelVersion": "0.14.0",
@@ -47,16 +49,16 @@ on the desktop side) is schema v2:
   "signature": "base64-encoded Ed25519 signature",
   "sourceRepo": "Eynzof/hermes-agent-cn",
   "sourceCommit": "01edd139...",
-  "minAppVersion": "0.1.0",
+  "minAppVersion": "0.7.0",
   "createdAt": "2026-05-16T03:00:00Z"
 }
 ```
 
-The signature is over the twelve canonical schema v2 fields concatenated with `\n`
-in this exact order:
+The signature is over the canonical fields concatenated with `\n` in this
+exact order — twelve fields for v2, plus `minAppVersion` as field #13 for v3:
 
 ```
-schemaVersion\nchannel\nruntimeVersion\nkernelVersion\nruntimeFlavor\nruntimeRevision\nplatform\narch\nartifactUrl\nsha256\nsourceRepo\nsourceCommit
+schemaVersion\nchannel\nruntimeVersion\nkernelVersion\nruntimeFlavor\nruntimeRevision\nplatform\narch\nartifactUrl\nsha256\nsourceRepo\nsourceCommit[\nminAppVersion]
 ```
 
 `scripts/sign_runtime_manifest.py` builds this payload identically to

--- a/docs/RUNTIME_VERSIONING.md
+++ b/docs/RUNTIME_VERSIONING.md
@@ -38,7 +38,7 @@ packaging bug, rotate runtime assets, or patch desktop-specific integration, we
 ship `0.14.0-cn.2`, `0.14.0-cn.3`, and so on. When the kernel moves to
 `0.15.0`, the CN revision resets to `cn.1`.
 
-## Manifest schema v2
+## Manifest schema (v3, with v2 transition support)
 
 Every release asset set includes one manifest per platform at:
 
@@ -47,12 +47,16 @@ https://github.com/Eynzof/hermes-agent-cn/releases/latest/download/stable-<platf
 ```
 
 The manifest is intentionally flat so GitHub Releases can host it directly.
-Schema v2 is not compatible with the older pre-release manifests; the desktop
-must reject anything that is not `schemaVersion: 2`.
+Current schema is **v3**: identical to v2 plus a **required, signed**
+`minAppVersion` field (the desktop forced-upgrade gate). Desktop >= 0.7.0
+accepts both v2 and v3; older desktops only accept v2, which is why v3
+manifests must not ship to the stable channel until 0.7.0 has rolled out
+(`--schema 2` on the signer exists for transition re-issues). Anything
+outside {2, 3} is rejected by the desktop.
 
 ```json
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "channel": "stable",
   "runtimeVersion": "0.14.0-cn.1",
   "kernelVersion": "0.14.0",
@@ -65,6 +69,7 @@ must reject anything that is not `schemaVersion: 2`.
   "signature": "...",
   "sourceRepo": "Eynzof/hermes-agent-cn",
   "sourceCommit": "...",
+  "minAppVersion": "0.7.0",
   "createdAt": "2026-05-19T00:00:00Z"
 }
 ```
@@ -87,11 +92,13 @@ artifactUrl
 sha256
 sourceRepo
 sourceCommit
+minAppVersion        # v3 only — appended as field #13; absent from v2 payloads
 ```
 
 Any change to that order must be made in both
 `scripts/sign_runtime_manifest.py` and
-`hermes-agent-cn-desktop/src/process/runtime.rs` in the same change.
+`hermes-agent-cn-desktop/src/process/runtime.rs` in the same change (both
+sides carry order-lock tests over the same fixture values).
 
 ## Cutting a runtime release
 

--- a/scripts/sign_runtime_manifest.py
+++ b/scripts/sign_runtime_manifest.py
@@ -6,10 +6,19 @@ it was built with. The canonical payload concatenated with ``\n`` matches what
 the Rust side reconstructs in ``signature_payload()`` — keep the field order in
 sync.
 
-Runtime versions are schema v2 and follow ``<kernelVersion>-cn.<revision>``.
-For example, tag ``runtime-v0.14.0-cn.1`` produces manifest
-``runtimeVersion=0.14.0-cn.1``, ``kernelVersion=0.14.0``,
-``runtimeFlavor=cn``, and ``runtimeRevision=1``.
+Manifest schemas:
+
+* v2 — the original 12-field signature payload; ``minAppVersion`` may be
+  written but is NOT signed (legacy clients ignore it).
+* v3 (default) — appends ``minAppVersion`` as signed payload field #13 and
+  requires it: it drives the desktop's forced-upgrade gate, so an unsigned or
+  missing value would defeat the gate. Only desktop >= 0.7.0 accepts v3;
+  ``--schema 2`` remains available to hand-issue transition manifests for
+  older clients.
+
+Runtime versions follow ``<kernelVersion>-cn.<revision>``. For example, tag
+``runtime-v0.14.0-cn.1`` produces manifest ``runtimeVersion=0.14.0-cn.1``,
+``kernelVersion=0.14.0``, ``runtimeFlavor=cn``, and ``runtimeRevision=1``.
 
 Usage:
     python scripts/sign_runtime_manifest.py \
@@ -24,7 +33,7 @@ Usage:
         --artifact-path dist/hermes-agent-cn-runtime-win32-x64.zip \
         --source-repo Eynzof/hermes-agent-cn \
         --source-commit "$GITHUB_SHA" \
-        --min-app-version 0.1.0 \
+        --min-app-version 0.7.0 \
         --output dist/stable-win32-x64.json
 """
 
@@ -50,13 +59,15 @@ except ImportError:
     )
 
 
-SCHEMA_VERSION = 2
+DEFAULT_SCHEMA_VERSION = 3
+SUPPORTED_SCHEMA_VERSIONS = (2, 3)
 
 # Field order MUST match `signature_payload()` in
 # hermes-agent-cn-desktop/src/process/runtime.rs. Any reorder here is a
 # silent verification failure on every desktop install — change both
-# sides together or not at all.
-_PAYLOAD_FIELDS = (
+# sides together or not at all. v3 appends `minAppVersion` as field #13;
+# the desktop side switches on schemaVersion the same way.
+_PAYLOAD_FIELDS_V2 = (
     "schemaVersion",
     "channel",
     "runtimeVersion",
@@ -70,10 +81,22 @@ _PAYLOAD_FIELDS = (
     "sourceRepo",
     "sourceCommit",
 )
+
+
+def payload_fields(schema_version: int) -> tuple[str, ...]:
+    if schema_version >= 3:
+        return _PAYLOAD_FIELDS_V2 + ("minAppVersion",)
+    return _PAYLOAD_FIELDS_V2
+
+
 _RUNTIME_VERSION_RE = re.compile(
     r"^(?P<kernel>\d+\.\d+\.\d+(?:[.-][0-9A-Za-z.-]+)?)-"
     r"(?P<flavor>[a-z][a-z0-9]*)\.(?P<revision>[1-9]\d*)$"
 )
+# Desktop shell versions are plain semver (optionally pre-release). The Rust
+# gate silently ignores unparseable minAppVersion values, so a typo here would
+# quietly disable the forced-upgrade gate — fail fast at signing time instead.
+_MIN_APP_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$")
 
 
 def _sha256_hex(path: Path) -> str:
@@ -164,12 +187,37 @@ def main() -> int:
     )
     p.add_argument("--source-repo", required=True, help="org/name slug")
     p.add_argument("--source-commit", required=True, help="commit SHA")
-    p.add_argument("--min-app-version", default=None, help="desktop client floor")
+    p.add_argument(
+        "--min-app-version",
+        default=None,
+        help="desktop client floor; REQUIRED for schema 3 (signed field)",
+    )
+    p.add_argument(
+        "--schema",
+        type=int,
+        default=DEFAULT_SCHEMA_VERSION,
+        choices=SUPPORTED_SCHEMA_VERSIONS,
+        help="manifest schema version; 2 only for transition re-issues to "
+        "pre-0.7.0 desktop clients",
+    )
     p.add_argument("--output", required=True, type=Path)
     args = p.parse_args()
 
     if args.runtime_revision < 1:
         raise SystemExit("--runtime-revision must be >= 1")
+    if args.schema >= 3:
+        if not args.min_app_version:
+            raise SystemExit(
+                "--min-app-version is required for schema 3 manifests: it is "
+                "part of the signed payload and drives the desktop "
+                "forced-upgrade gate."
+            )
+        if not _MIN_APP_VERSION_RE.match(args.min_app_version):
+            raise SystemExit(
+                "--min-app-version must be semver (X.Y.Z), got "
+                f"{args.min_app_version!r} — the desktop gate ignores "
+                "unparseable values, which would silently disable it."
+            )
     _validate_runtime_version(
         args.runtime_version,
         args.kernel_version,
@@ -189,7 +237,7 @@ def main() -> int:
     print(f"sha256({args.artifact_path.name}) = {sha256}", file=sys.stderr)
 
     manifest = {
-        "schemaVersion": SCHEMA_VERSION,
+        "schemaVersion": args.schema,
         "channel": args.channel,
         "runtimeVersion": args.runtime_version,
         "kernelVersion": args.kernel_version,
@@ -208,7 +256,7 @@ def main() -> int:
         _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     )
 
-    payload = "\n".join(str(manifest[f]) for f in _PAYLOAD_FIELDS).encode()
+    payload = "\n".join(str(manifest[f]) for f in payload_fields(args.schema)).encode()
     key = _load_private_key()
     signature = key.sign(payload)
     manifest["signature"] = base64.standard_b64encode(signature).decode()

--- a/tests/scripts/test_sign_runtime_manifest.py
+++ b/tests/scripts/test_sign_runtime_manifest.py
@@ -1,0 +1,101 @@
+"""Tests for the runtime manifest signer's cross-language payload contract.
+
+The payload field order is a wire contract with the desktop client
+(`Hermes-CN-Desktop/src/process/runtime.rs::signature_payload`), locked on the
+Rust side by `signature_payload_has_stable_field_order` /
+`signature_payload_v3_appends_min_app_version_as_field_13`. The fixtures here
+use the same literal values as those Rust tests so both suites assert the same
+golden payload without sharing files across repos.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "sign_runtime_manifest.py"
+_SPEC = importlib.util.spec_from_file_location("sign_runtime_manifest", _SCRIPT_PATH)
+assert _SPEC is not None
+_module = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_module)
+
+
+# Mirrors Hermes-CN-Desktop fixture_manifest() (src/process/runtime.rs tests).
+_FIXTURE = {
+    "schemaVersion": 2,
+    "channel": "stable",
+    "runtimeVersion": "1.2.3-cn.1",
+    "kernelVersion": "1.2.3",
+    "runtimeFlavor": "cn",
+    "runtimeRevision": 1,
+    "platform": "linux",
+    "arch": "x64",
+    "artifactUrl": "https://example.com/foo.zip",
+    "sha256": "deadbeef",
+    "sourceRepo": "owner/repo",
+    "sourceCommit": "abc123",
+    "minAppVersion": "0.7.0",
+}
+
+
+def _payload(schema_version: int) -> str:
+    manifest = dict(_FIXTURE, schemaVersion=schema_version)
+    return "\n".join(str(manifest[f]) for f in _module.payload_fields(schema_version))
+
+
+def test_v2_payload_field_order_is_locked():
+    assert _payload(2).split("\n") == [
+        "2",
+        "stable",
+        "1.2.3-cn.1",
+        "1.2.3",
+        "cn",
+        "1",
+        "linux",
+        "x64",
+        "https://example.com/foo.zip",
+        "deadbeef",
+        "owner/repo",
+        "abc123",
+    ]
+
+
+def test_v3_payload_appends_min_app_version_as_field_13():
+    lines = _payload(3).split("\n")
+    assert len(lines) == 13
+    assert lines[0] == "3"
+    assert lines[12] == "0.7.0"
+    # Fields 2..12 keep the exact v2 order.
+    assert lines[1:12] == _payload(2).split("\n")[1:12]
+
+
+def test_v2_payload_never_includes_min_app_version():
+    # v2 signatures must stay stable whether or not the optional (unsigned)
+    # minAppVersion field is present in the written manifest.
+    assert "minAppVersion" not in _module.payload_fields(2)
+    assert len(_module.payload_fields(2)) == 12
+
+
+def test_default_schema_is_v3():
+    assert _module.DEFAULT_SCHEMA_VERSION == 3
+    assert _module.SUPPORTED_SCHEMA_VERSIONS == (2, 3)
+
+
+@pytest.mark.parametrize(
+    ("value", "ok"),
+    [
+        ("0.7.0", True),
+        ("1.0.0-rc.1", True),
+        ("0.7", False),
+        ("v0.7.0", False),
+        ("latest", False),
+        ("", False),
+    ],
+)
+def test_min_app_version_format_gate(value: str, ok: bool):
+    # The desktop gate silently ignores unparseable minAppVersion values, so
+    # the signer must reject them at release time.
+    assert bool(_module._MIN_APP_VERSION_RE.match(value)) is ok


### PR DESCRIPTION
## 背景

热更新三轨道落地·轨道 A 收口的 Core 侧（与 [Hermes-CN-Desktop PR #452](https://github.com/Eynzof/Hermes-CN-Desktop/pull/452) 配套）。`minAppVersion` 此前是未签名的可选字段：客户端不读取，且即使读取也可被中间人抹除绕过强制升级门。schema v3 把它变成**必填 + 签名保护**的第 13 个载荷字段。

## ⚠️ 合并/发布顺序约束（客户端先行）

**本 PR 可以合并，但在 Desktop 0.7.0（v2/v3 双读客户端）发布铺开之前，不要对 stable 渠道打 `runtime-v*` tag**——旧桌面端（≤0.6.3）对 v3 清单会 schema 校验失败并停止接收内核更新（优雅失败不 brick，但用户需先手动升级外壳）。过渡期如需给旧客户端补发，可用 `--schema 2` 手动签发。

## 改动

- `scripts/sign_runtime_manifest.py`：默认 `--schema 3`；v3 强制 `--min-app-version` 必填且 semver 格式（客户端对不可解析值静默放行，签名侧必须兜住）；保留 `--schema 2` 过渡能力
- `.github/workflows/release-runtime.yml`：新增 `min_app_version` dispatch 输入 + `RUNTIME_MIN_APP_VERSION_DEFAULT: "0.7.0"` 默认值（桌面↔内核兼容表锚点，含注释说明），签名步传 `--min-app-version`
- `tests/scripts/test_sign_runtime_manifest.py`：v2/v3 载荷顺序锁（与 Desktop 侧 Rust 测试共用同一组 fixture 字面值互为金样）、v2 不含 minAppVersion、格式闸门
- 文档：`RUNTIME_VERSIONING.md` / `RUNTIME_RELEASES.md` 同步 v3 契约

## 验证

- `scripts/run_tests.sh tests/scripts/test_sign_runtime_manifest.py`：10 通过
- ruff 干净
- 本地端到端冒烟：v3 缺 minAppVersion 拒签 / 非法格式拒签 / v3 签名验证 roundtrip / `--schema 2` 过渡模式 roundtrip 全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)