### PR TITLE
feat: 完善插件清单与生命周期管理

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1333,59 +1333,7 @@ class PluginManager:
 
     def _discover_and_load_inner(self) -> None:
         """The actual discovery sweep — see :meth:`discover_and_load`."""
-        manifests: List[PluginManifest] = []
-
-        # 1. Bundled plugins (<repo>/plugins/<name>/)
-        #
-        # Repo-shipped plugins live next to hermes_cli/. Two layouts are
-        # supported (see ``_scan_directory`` for details):
-        #
-        #   - flat: ``plugins/disk-cleanup/plugin.yaml`` (standalone)
-        #   - category: ``plugins/image_gen/openai/plugin.yaml`` (backend)
-        #
-        # ``memory/``, ``context_engine/``, and ``model-providers/`` are
-        # skipped at the top level — they have their own discovery systems
-        # (plugins/memory/__init__.py, providers/__init__.py). ``platforms/``
-        # is a category holding platform adapters (scanned one level deeper
-        # below).
-        repo_plugins = get_bundled_plugins_dir()
-        logger.debug("Scanning bundled plugins: %s", repo_plugins)
-        bundled = self._scan_directory(
-            repo_plugins,
-            source="bundled",
-            skip_names={"memory", "context_engine", "platforms", "model-providers"},
-        )
-        logger.debug("  bundled (top-level): %d manifest(s)", len(bundled))
-        manifests.extend(bundled)
-        bundled_platforms = self._scan_directory(
-            repo_plugins / "platforms", source="bundled"
-        )
-        logger.debug("  bundled/platforms: %d manifest(s)", len(bundled_platforms))
-        manifests.extend(bundled_platforms)
-
-        # 2. User plugins (~/.hermes/plugins/)
-        user_dir = get_hermes_home() / "plugins"
-        logger.debug("Scanning user plugins: %s", user_dir)
-        user_manifests = self._scan_directory(user_dir, source="user")
-        logger.debug("  user: %d manifest(s)", len(user_manifests))
-        manifests.extend(user_manifests)
-
-        # 3. Project plugins (./.hermes/plugins/)
-        if _env_enabled("HERMES_ENABLE_PROJECT_PLUGINS"):
-            project_dir = Path.cwd() / ".hermes" / "plugins"
-            logger.debug("Scanning project plugins: %s", project_dir)
-            project_manifests = self._scan_directory(project_dir, source="project")
-            logger.debug("  project: %d manifest(s)", len(project_manifests))
-            manifests.extend(project_manifests)
-        else:
-            logger.debug(
-                "Project plugins disabled (set HERMES_ENABLE_PROJECT_PLUGINS=1 to enable)"
-            )
-
-        # 4. Pip / entry-point plugins
-        ep_manifests = self._scan_entry_points()
-        logger.debug("  entrypoints: %d manifest(s)", len(ep_manifests))
-        manifests.extend(ep_manifests)
+        manifests = self.scan_manifests(include_managed=False)
 
         # Load each manifest (skip user-disabled plugins).
         # Later sources override earlier ones on key collision — user
@@ -1491,6 +1439,69 @@ class PluginManager:
                 len(self._plugins),
                 sum(1 for p in self._plugins.values() if p.enabled),
             )
+
+    def scan_manifests(
+        self,
+        *,
+        include_managed: bool = True,
+        user_dir: Optional[Path] = None,
+    ) -> List[PluginManifest]:
+        """Return deduplicated plugin metadata without importing plugin code.
+
+        This is the canonical source scan used by both runtime discovery and
+        dashboard inventory.  ``include_managed=False`` mirrors the runtime
+        loader: bundled memory and model-provider plugins stay with their own
+        discovery systems, while bundled platform adapters remain visible to
+        the deferred platform loader.  Inventory callers use the default so
+        provider-managed manifests are listed as read-only entries.
+
+        Later sources override earlier ones on canonical key collisions.
+        Project plugins are included only when the existing
+        ``HERMES_ENABLE_PROJECT_PLUGINS`` gate is enabled.
+        """
+        manifests: List[PluginManifest] = []
+        repo_plugins = get_bundled_plugins_dir()
+
+        logger.debug("Scanning bundled plugins: %s", repo_plugins)
+        if include_managed:
+            bundled = self._scan_directory(repo_plugins, source="bundled")
+        else:
+            bundled = self._scan_directory(
+                repo_plugins,
+                source="bundled",
+                skip_names={"memory", "context_engine", "platforms", "model-providers"},
+            )
+            bundled.extend(
+                self._scan_directory(repo_plugins / "platforms", source="bundled")
+            )
+        logger.debug("  bundled: %d manifest(s)", len(bundled))
+        manifests.extend(bundled)
+
+        resolved_user_dir = user_dir or (get_hermes_home() / "plugins")
+        logger.debug("Scanning user plugins: %s", resolved_user_dir)
+        user_manifests = self._scan_directory(resolved_user_dir, source="user")
+        logger.debug("  user: %d manifest(s)", len(user_manifests))
+        manifests.extend(user_manifests)
+
+        if _env_enabled("HERMES_ENABLE_PROJECT_PLUGINS"):
+            project_dir = Path.cwd() / ".hermes" / "plugins"
+            logger.debug("Scanning project plugins: %s", project_dir)
+            project_manifests = self._scan_directory(project_dir, source="project")
+            logger.debug("  project: %d manifest(s)", len(project_manifests))
+            manifests.extend(project_manifests)
+        else:
+            logger.debug(
+                "Project plugins disabled (set HERMES_ENABLE_PROJECT_PLUGINS=1 to enable)"
+            )
+
+        ep_manifests = self._scan_entry_points()
+        logger.debug("  entrypoints: %d manifest(s)", len(ep_manifests))
+        manifests.extend(ep_manifests)
+
+        winners: Dict[str, PluginManifest] = {}
+        for manifest in manifests:
+            winners[manifest.key or manifest.name] = manifest
+        return list(winners.values())
 
     # -----------------------------------------------------------------------
     # Directory scanning
@@ -1649,14 +1660,24 @@ class PluginManager:
                 "Parsed manifest: key=%s name=%s kind=%s source=%s path=%s",
                 key, name, kind, source, plugin_dir,
             )
+            provides_tools = data.get("provides_tools", [])
+            if not isinstance(provides_tools, list):
+                provides_tools = []
+            provides_hooks = data.get("provides_hooks", data.get("hooks", []))
+            if not isinstance(provides_hooks, list):
+                provides_hooks = []
+            requires_env = data.get("requires_env", [])
+            if not isinstance(requires_env, list):
+                requires_env = []
+
             return PluginManifest(
-                name=name,
+                name=str(name),
                 version=str(data.get("version", "")),
-                description=data.get("description", ""),
-                author=data.get("author", ""),
-                requires_env=data.get("requires_env", []),
-                provides_tools=data.get("provides_tools", []),
-                provides_hooks=data.get("provides_hooks", []),
+                description=str(data.get("description", "") or ""),
+                author=str(data.get("author", "") or ""),
+                requires_env=requires_env,
+                provides_tools=[str(item) for item in provides_tools if isinstance(item, str)],
+                provides_hooks=[str(item) for item in provides_hooks if isinstance(item, str)],
                 source=source,
                 path=str(plugin_dir),
                 kind=kind,
@@ -1686,8 +1707,12 @@ class PluginManager:
                 group_eps = [ep for ep in eps if ep.group == ENTRY_POINTS_GROUP]
 
             for ep in group_eps:
+                dist = getattr(ep, "dist", None)
+                metadata = getattr(dist, "metadata", None)
                 manifest = PluginManifest(
                     name=ep.name,
+                    version=str(getattr(dist, "version", "") or ""),
+                    description=str(metadata.get("Summary", "") or "") if metadata else "",
                     source="entrypoint",
                     path=ep.value,
                     key=ep.name,
@@ -2044,6 +2069,22 @@ class PluginManager:
 # ---------------------------------------------------------------------------
 
 _plugin_manager: Optional[PluginManager] = None
+
+
+def scan_plugin_manifests(
+    *,
+    include_managed: bool = True,
+    user_dir: Optional[Path] = None,
+) -> List[PluginManifest]:
+    """Scan plugin manifests without importing or registering plugin code.
+
+    A fresh manager is intentional: inventory reads must not mutate the
+    process-global runtime registry or mark discovery as completed.
+    """
+    return PluginManager().scan_manifests(
+        include_managed=include_managed,
+        user_dir=user_dir,
+    )
 
 
 def get_plugin_manager() -> PluginManager:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -791,6 +791,32 @@ def _resolve_plugin_key_and_source(name: str) -> Optional[tuple]:
     return None
 
 
+def _resolve_plugin_manifest(name: str):
+    """Resolve a name/key/unique leaf to canonical metadata without imports."""
+    from hermes_cli.plugins import scan_plugin_manifests
+
+    manifests = scan_plugin_manifests(
+        include_managed=True,
+        user_dir=_plugins_dir(),
+    )
+    for manifest in manifests:
+        key = manifest.key or manifest.name
+        if name == key or name == manifest.name:
+            return manifest
+    leaf_matches = [
+        manifest
+        for manifest in manifests
+        if name == (manifest.key or manifest.name).split("/")[-1]
+    ]
+    return leaf_matches[0] if len(leaf_matches) == 1 else None
+
+
+def _plugin_config_aliases(manifest) -> set[str]:
+    """Return every legacy identifier that can gate one plugin."""
+    key = manifest.key or manifest.name
+    return {key, manifest.name, key.split("/")[-1]}
+
+
 def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
     """Write ``plugins.entries.<plugin_id>.<key> = value`` into config.yaml."""
     from hermes_cli.config import load_config, save_config
@@ -1018,25 +1044,30 @@ def _discover_all_plugins() -> list:
     """Return a list of (name, version, description, source, dir_path, key) for
     every plugin the loader can see — user + bundled + project + entry point.
 
-    Matches the ordering/dedup of ``PluginManager.discover_and_load``:
-    bundled first, then user, then project, then entry points. Later sources
-    override earlier ones on key collision.
+    Delegates to the metadata-only canonical scanner used by
+    ``PluginManager`` so CLI and Dashboard status cannot drift from runtime
+    discovery.  No plugin module is imported by this path.
     """
-    seen: dict = {}  # key -> (name, version, description, source, path, key)
+    from hermes_cli.plugins import scan_plugin_manifests
 
-    # Bundled (<repo>/plugins/<name>/), excluding memory/ and context_engine/
-    from hermes_cli.plugins import get_bundled_plugins_dir
-    repo_plugins = get_bundled_plugins_dir()
-    for base, source, skip in (
-        (repo_plugins, "bundled", {"memory", "context_engine"}),
-        (_plugins_dir(), "user", set()),
+    entries = []
+    for manifest in scan_plugin_manifests(
+        include_managed=True,
+        user_dir=_plugins_dir(),
     ):
-        _scan_level(base, source, skip, "", 0, seen)
-
-    # Entry-point plugins (installed as Python packages; no plugin directory).
-    for name, version, description, path in _discover_entrypoint_plugins():
-        seen[name] = (name, version, description, "entrypoint", path, name)
-    return list(seen.values())
+        source = manifest.source
+        path: Path | str = manifest.path or ""
+        if source == "user" and manifest.path and (Path(manifest.path) / ".git").exists():
+            source = "git"
+        entries.append((
+            manifest.name,
+            manifest.version,
+            manifest.description,
+            source,
+            path,
+            manifest.key or manifest.name,
+        ))
+    return entries
 
 
 def _discover_entrypoint_plugins() -> list[tuple[str, str, str, str]]:
@@ -1868,34 +1899,41 @@ def _toggle_plugin_toolset(name: str, *, enable: bool) -> None:
 def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str, Any]:
     """Enable or disable a plugin in ``config.yaml`` (runtime allow/deny lists).
 
-    For plugins that provide tools (toolsets), also toggles the toolset in
-    ``platform_toolsets`` so the agent actually sees the tools in sessions.
+    The dashboard always persists the canonical path-derived key and removes
+    stale bare-name/manifest-name aliases.  It deliberately does not rescan or
+    import the plugin in this process; the new state applies to new sessions.
     """
-    if not _plugin_exists(name):
+    manifest = _resolve_plugin_manifest(name)
+    if manifest is None:
         return {"ok": False, "error": f"Plugin '{name}' is not installed or bundled."}
+
+    key = manifest.key or manifest.name
+    if manifest.kind in {"exclusive", "model-provider"}:
+        return {
+            "ok": False,
+            "error": f"Plugin '{key}' is managed by its provider settings.",
+        }
 
     en = _get_enabled_set()
     dis = _get_disabled_set()
+    aliases = _plugin_config_aliases(manifest)
 
     if enabled:
-        if name in en and name not in dis:
-            return {"ok": True, "name": name, "unchanged": True}
-        en.add(name)
-        dis.discard(name)
+        unchanged = key in en and not (aliases & dis) and not ((aliases - {key}) & en)
+        en.difference_update(aliases)
+        en.add(key)
+        dis.difference_update(aliases)
         _save_enabled_set(en)
         _save_disabled_set(dis)
-        _toggle_plugin_toolset(name, enable=True)
-        return {"ok": True, "name": name, "unchanged": False}
+        return {"ok": True, "name": key, "unchanged": unchanged}
 
-    if name not in en and name in dis:
-        return {"ok": True, "name": name, "unchanged": True}
-
-    en.discard(name)
-    dis.add(name)
+    unchanged = not (aliases & en) and key in dis and not ((aliases - {key}) & dis)
+    en.difference_update(aliases)
+    dis.difference_update(aliases)
+    dis.add(key)
     _save_enabled_set(en)
     _save_disabled_set(dis)
-    _toggle_plugin_toolset(name, enable=False)
-    return {"ok": True, "name": name, "unchanged": False}
+    return {"ok": True, "name": key, "unchanged": unchanged}
 
 
 def _user_installed_plugin_dir(name: str) -> Optional[Path]:
@@ -1910,17 +1948,24 @@ def _user_installed_plugin_dir(name: str) -> Optional[Path]:
 
 def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
     """``git pull`` inside ``~/.hermes/plugins/<name>``."""
-    target = _user_installed_plugin_dir(name)
-    if target is None:
+    manifest = _resolve_plugin_manifest(name)
+    key = (manifest.key or manifest.name) if manifest is not None else name
+    target = Path(manifest.path) if manifest is not None and manifest.path else None
+    plugins_root = _plugins_dir().resolve()
+    try:
+        under_user_tree = target is not None and target.resolve().is_relative_to(plugins_root)
+    except (OSError, ValueError):
+        under_user_tree = False
+    if manifest is None or manifest.source != "user" or not under_user_tree or not target.is_dir():
         return {
             "ok": False,
-            "error": f"Plugin '{name}' was not found under {_plugins_dir()}.",
+            "error": f"Plugin '{key}' was not found under {_plugins_dir()}.",
         }
 
     if not (target / ".git").exists():
         return {
             "ok": False,
-            "error": f"Plugin '{name}' is not a git checkout; cannot pull updates.",
+            "error": f"Plugin '{key}' is not a git checkout; cannot pull updates.",
         }
 
     ok, msg = _git_pull_plugin_dir(target)
@@ -1931,7 +1976,7 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
 
     _copy_example_files(target, Console())
     unchanged = "Already up to date" in msg
-    return {"ok": True, "name": name, "output": msg, "unchanged": unchanged}
+    return {"ok": True, "name": key, "output": msg, "unchanged": unchanged}
 
 
 def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
@@ -1957,22 +2002,59 @@ def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
     return True, result.stdout.strip()
 
 
+def _remove_plugin_config_references(manifest) -> None:
+    """Remove allow/deny/entry state for an uninstalled plugin."""
+    from hermes_cli.config import load_config, save_config
+
+    config = load_config()
+    plugins_cfg = config.get("plugins")
+    if not isinstance(plugins_cfg, dict):
+        return
+
+    aliases = _plugin_config_aliases(manifest)
+    changed = False
+    for field in ("enabled", "disabled"):
+        raw = plugins_cfg.get(field)
+        if not isinstance(raw, list):
+            continue
+        cleaned = [item for item in raw if item not in aliases]
+        if cleaned != raw:
+            plugins_cfg[field] = cleaned
+            changed = True
+
+    entries = plugins_cfg.get("entries")
+    if isinstance(entries, dict):
+        for alias in aliases:
+            if alias in entries:
+                entries.pop(alias, None)
+                changed = True
+
+    if changed:
+        save_config(config)
+
+
 def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
     """Delete a plugin tree under ``~/.hermes/plugins/`` only."""
     plugins_dir = _plugins_dir()
-    for n, _ver, _d, src, _path, _key in _discover_all_plugins():
-        if n == name and src == "bundled":
-            return {"ok": False, "error": "Bundled plugins cannot be removed from the dashboard."}
+    manifest = _resolve_plugin_manifest(name)
+    key = (manifest.key or manifest.name) if manifest is not None else name
+    if manifest is not None and manifest.source == "bundled":
+        return {"ok": False, "error": "Bundled plugins cannot be removed from the dashboard."}
 
-    target = _user_installed_plugin_dir(name)
-    if target is None:
+    target = Path(manifest.path) if manifest is not None and manifest.path else None
+    try:
+        under_user_tree = target is not None and target.resolve().is_relative_to(plugins_dir.resolve())
+    except (OSError, ValueError):
+        under_user_tree = False
+    if manifest is None or manifest.source != "user" or not under_user_tree or not target.is_dir():
         return {
             "ok": False,
-            "error": f"Plugin '{name}' was not found under {plugins_dir}.",
+            "error": f"Plugin '{key}' was not found under {plugins_dir}.",
         }
 
     shutil.rmtree(target)
-    return {"ok": True, "name": name}
+    _remove_plugin_config_references(manifest)
+    return {"ok": True, "name": key}
 
 
 def plugins_command(args) -> None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17024,17 +17024,54 @@ def _strip_dashboard_manifest(p: Dict[str, Any]) -> Dict[str, Any]:
     return {k: v for k, v in p.items() if not k.startswith("_")}
 
 
+def _plugin_required_env_names(items: Any) -> List[str]:
+    """Normalize string/dict ``requires_env`` manifest entries."""
+    if not isinstance(items, list):
+        return []
+    names: List[str] = []
+    for item in items:
+        if isinstance(item, str):
+            name = item.strip()
+        elif isinstance(item, dict):
+            name = str(item.get("name") or "").strip()
+        else:
+            name = ""
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
+def _plugin_inventory_status(
+    manifest: Any,
+    enabled_set: set,
+    disabled_set: set,
+) -> tuple[str, str, bool]:
+    """Return ``(config_status, effective_status, can_toggle)``."""
+    key = manifest.key or manifest.name
+    aliases = {key, manifest.name, key.split("/")[-1]}
+    provider_managed = manifest.kind in {"exclusive", "model-provider"}
+
+    if aliases & disabled_set:
+        return "disabled", "disabled", not provider_managed
+    if provider_managed:
+        return "provider-managed", "provider-managed", False
+    if aliases & enabled_set:
+        return "enabled", "enabled", True
+    if manifest.source == "bundled" and manifest.kind in {"backend", "platform"}:
+        return "auto", "auto-active", True
+    return "not-enabled", "inactive", True
+
+
 def _merged_plugins_hub() -> Dict[str, Any]:
     """Agent discovery + dashboard manifests + optional provider picker metadata."""
     from hermes_cli.plugins_cmd import (
-        _discover_all_plugins,
         _get_current_context_engine,
         _get_current_memory_provider,
         _discover_context_engines,
         _get_disabled_set,
         _get_enabled_set,
-        _read_manifest as _read_plugin_manifest_at,
     )
+    from hermes_cli.plugins import scan_plugin_manifests
 
     dashboard_list = _get_dashboard_plugins()
     dash_by_name = {str(p["name"]): p for p in dashboard_list}
@@ -17049,66 +17086,84 @@ def _merged_plugins_hub() -> Dict[str, Any]:
     plugins_root_resolved = (get_hermes_home() / "plugins").resolve()
     rows: List[Dict[str, Any]] = []
 
-    for name, version, description, source, dir_str, key in _discover_all_plugins():
-        # Both the path-derived key (nested category plugins) and the bare
-        # manifest name count for enabled/disabled state, matching the runtime
-        # loader's back-compat lookup.
-        aliases = {name}
-        if key:
-            aliases.add(key)
-        if aliases & disabled_set:
-            runtime_status = "disabled"
-        elif aliases & enabled_set:
-            runtime_status = "enabled"
-        else:
-            runtime_status = "inactive"
-
-        dir_path = Path(dir_str)
-        dm = dash_by_name.get(name)
-        has_dash_manifest = dm is not None or (dir_path / "dashboard" / "manifest.json").exists()
-
-        under_user_tree = False
-        try:
-            dir_path.resolve().relative_to(plugins_root_resolved)
-            under_user_tree = True
-        except ValueError:
-            pass
-
-        can_remove_update = (
-            source in {"user", "git"} and under_user_tree and Path(dir_str).is_dir()
+    manifests = scan_plugin_manifests(
+        include_managed=True,
+        user_dir=get_hermes_home() / "plugins",
+    )
+    for manifest in manifests:
+        name = manifest.name
+        key = manifest.key or name
+        config_status, effective_status, can_toggle = _plugin_inventory_status(
+            manifest,
+            enabled_set,
+            disabled_set,
+        )
+        runtime_status = (
+            "disabled"
+            if effective_status == "disabled"
+            else "inactive"
+            if effective_status == "inactive"
+            else "enabled"
         )
 
-        # Check if this plugin provides tools that require auth
-        auth_required = False
-        auth_command = ""
-        manifest_data = _read_plugin_manifest_at(dir_path)
-        provides_tools = manifest_data.get("provides_tools") or []
-        if provides_tools:
+        dir_str = manifest.path or ""
+        dir_path = Path(dir_str) if dir_str else None
+        dm = dash_by_name.get(name)
+        has_dash_manifest = dm is not None or bool(
+            dir_path and (dir_path / "dashboard" / "manifest.json").exists()
+        )
+
+        under_user_tree = False
+        if dir_path is not None:
             try:
-                from tools.registry import registry
-                for tname in provides_tools:
-                    entry = registry.get_entry(tname)
-                    if entry and entry.check_fn and not entry.check_fn():
-                        auth_required = True
-                        auth_command = f"hermes auth {name}"
-                        break
-            except Exception:
+                dir_path.resolve().relative_to(plugins_root_resolved)
+                under_user_tree = True
+            except (OSError, ValueError):
                 pass
+
+        can_remove_update = (
+            manifest.source == "user"
+            and under_user_tree
+            and dir_path is not None
+            and dir_path.is_dir()
+        )
+        source = (
+            "git"
+            if can_remove_update and dir_path is not None and (dir_path / ".git").exists()
+            else manifest.source
+        )
+
+        requires_env = _plugin_required_env_names(manifest.requires_env)
+        missing_env = [env_name for env_name in requires_env if not os.getenv(env_name)]
+        auth_required = bool(missing_env)
+        auth_command = f"hermes auth {name}" if auth_required else ""
 
         rows.append({
             "name": name,
-            "version": version or "",
-            "description": description or "",
+            "key": key,
+            "kind": manifest.kind,
+            "version": manifest.version or "",
+            "description": manifest.description or "",
+            "author": manifest.author or "",
             "source": source,
             "runtime_status": runtime_status,
+            "config_status": config_status,
+            "effective_status": effective_status,
+            "can_toggle": can_toggle,
+            "provides_tools": list(manifest.provides_tools),
+            "provides_hooks": list(manifest.provides_hooks),
+            "requires_env": requires_env,
+            "missing_env": missing_env,
             "has_dashboard_manifest": has_dash_manifest,
             "dashboard_manifest": _strip_dashboard_manifest(dm) if dm else None,
             "path": dir_str,
             "can_remove": can_remove_update,
-            "can_update_git": can_remove_update and (Path(dir_str) / ".git").exists(),
+            "can_update_git": can_remove_update and bool(
+                dir_path and (dir_path / ".git").exists()
+            ),
             "auth_required": auth_required,
             "auth_command": auth_command,
-            "user_hidden": name in hidden_plugins,
+            "user_hidden": name in hidden_plugins or key in hidden_plugins,
         })
 
     agent_names = {r["name"] for r in rows}

--- a/tests/hermes_cli/test_plugin_inventory.py
+++ b/tests/hermes_cli/test_plugin_inventory.py
@@ -1,0 +1,272 @@
+"""Plugin inventory contracts shared by runtime, Dashboard, and desktop UI."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+
+def _write_plugin(
+    root: Path,
+    key: str,
+    *,
+    name: str | None = None,
+    kind: str = "standalone",
+    version: str = "1.0.0",
+    extra: dict | None = None,
+    init_body: str = "def register(ctx):\n    pass\n",
+) -> Path:
+    plugin_dir = root.joinpath(*key.split("/"))
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "name": name or key.split("/")[-1],
+        "kind": kind,
+        "version": version,
+        "description": f"{key} plugin",
+        "author": "Hermes Test",
+    }
+    manifest.update(extra or {})
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump(manifest),
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(init_body, encoding="utf-8")
+    return plugin_dir
+
+
+def test_canonical_scan_deduplicates_sources_and_keeps_nested_metadata(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import plugins
+
+    bundled = tmp_path / "bundled"
+    user = tmp_path / "user"
+    project_root = tmp_path / "project"
+    _write_plugin(bundled, "image_gen/example", version="1.0.0")
+    _write_plugin(user, "image_gen/example", version="2.0.0")
+    _write_plugin(
+        project_root / ".hermes" / "plugins",
+        "image_gen/example",
+        version="3.0.0",
+        extra={
+            "provides_tools": ["example_tool"],
+            "hooks": ["on_session_start"],
+            "requires_env": [{"name": "EXAMPLE_API_KEY"}],
+        },
+    )
+
+    monkeypatch.setattr(plugins, "get_bundled_plugins_dir", lambda: bundled)
+    monkeypatch.setattr(plugins.importlib.metadata, "entry_points", lambda: [])
+    monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "1")
+    monkeypatch.chdir(project_root)
+
+    manifests = plugins.scan_plugin_manifests(user_dir=user)
+    matches = [m for m in manifests if m.key == "image_gen/example"]
+
+    assert len(matches) == 1
+    manifest = matches[0]
+    assert manifest.source == "project"
+    assert manifest.version == "3.0.0"
+    assert manifest.provides_tools == ["example_tool"]
+    assert manifest.provides_hooks == ["on_session_start"]
+    assert manifest.requires_env == [{"name": "EXAMPLE_API_KEY"}]
+
+
+def test_inventory_scan_never_imports_plugin_code(tmp_path, monkeypatch):
+    from hermes_cli import plugins
+
+    bundled = tmp_path / "bundled"
+    user = tmp_path / "user"
+    marker = tmp_path / "executed.txt"
+    _write_plugin(
+        user,
+        "safe-scan",
+        init_body=f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\n",
+    )
+    monkeypatch.setattr(plugins, "get_bundled_plugins_dir", lambda: bundled)
+    monkeypatch.setattr(plugins.importlib.metadata, "entry_points", lambda: [])
+
+    manifests = plugins.scan_plugin_manifests(user_dir=user)
+
+    assert any(m.key == "safe-scan" for m in manifests)
+    assert not marker.exists()
+
+
+def test_inventory_honors_project_gate_and_reports_bad_manifest(
+    tmp_path, monkeypatch, caplog
+):
+    from hermes_cli import plugins
+
+    bundled = tmp_path / "bundled"
+    user = tmp_path / "user"
+    project_root = tmp_path / "project"
+    _write_plugin(project_root / ".hermes" / "plugins", "project-only")
+    bad = user / "broken"
+    bad.mkdir(parents=True)
+    (bad / "plugin.yaml").write_text(": : bad [[[", encoding="utf-8")
+
+    monkeypatch.setattr(plugins, "get_bundled_plugins_dir", lambda: bundled)
+    monkeypatch.setattr(plugins.importlib.metadata, "entry_points", lambda: [])
+    monkeypatch.chdir(project_root)
+    monkeypatch.delenv("HERMES_ENABLE_PROJECT_PLUGINS", raising=False)
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+        manifests = plugins.scan_plugin_manifests(user_dir=user)
+
+    assert all(m.key != "project-only" for m in manifests)
+    assert any("Failed to parse" in record.message for record in caplog.records)
+
+    monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "true")
+    manifests = plugins.scan_plugin_manifests(user_dir=user)
+    assert any(m.key == "project-only" for m in manifests)
+
+
+def test_inventory_status_rules_cover_auto_provider_and_explicit_disable():
+    from hermes_cli.plugins import PluginManifest
+    from hermes_cli.web_server import _plugin_inventory_status
+
+    backend = PluginManifest(
+        name="openai",
+        key="image_gen/openai",
+        kind="backend",
+        source="bundled",
+    )
+    provider = PluginManifest(
+        name="honcho",
+        key="memory/honcho",
+        kind="exclusive",
+        source="bundled",
+    )
+
+    assert _plugin_inventory_status(backend, set(), set()) == (
+        "auto",
+        "auto-active",
+        True,
+    )
+    assert _plugin_inventory_status(provider, set(), set()) == (
+        "provider-managed",
+        "provider-managed",
+        False,
+    )
+    assert _plugin_inventory_status(backend, {"image_gen/openai"}, {"openai"}) == (
+        "disabled",
+        "disabled",
+        True,
+    )
+
+
+def test_plugins_hub_keeps_legacy_fields_and_adds_inventory_contract(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import plugins, plugins_cmd, web_server
+
+    plugin_dir = tmp_path / "plugins" / "demo"
+    plugin_dir.mkdir(parents=True)
+    manifest = plugins.PluginManifest(
+        name="demo",
+        key="demo",
+        kind="standalone",
+        source="user",
+        path=str(plugin_dir),
+        version="2.0.0",
+        description="Demo plugin",
+        author="Hermes Test",
+        provides_tools=["demo_tool"],
+        provides_hooks=["on_session_start"],
+        requires_env=["DEMO_API_KEY"],
+    )
+    monkeypatch.delenv("DEMO_API_KEY", raising=False)
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(web_server, "_get_dashboard_plugins", lambda: [])
+    monkeypatch.setattr(web_server, "load_config", lambda: {"dashboard": {}})
+    monkeypatch.setattr(web_server, "_discover_memory_provider_statuses", lambda: [])
+    monkeypatch.setattr(plugins, "scan_plugin_manifests", lambda **_kwargs: [manifest])
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"demo"})
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_current_memory_provider", lambda: "")
+    monkeypatch.setattr(plugins_cmd, "_get_current_context_engine", lambda: "compressor")
+    monkeypatch.setattr(plugins_cmd, "_discover_context_engines", lambda: [])
+
+    payload = web_server._merged_plugins_hub()
+    row = payload["plugins"][0]
+
+    assert row["name"] == "demo"
+    assert row["runtime_status"] == "enabled"
+    assert row["can_remove"] is True
+    assert row["key"] == "demo"
+    assert row["kind"] == "standalone"
+    assert row["config_status"] == "enabled"
+    assert row["effective_status"] == "enabled"
+    assert row["can_toggle"] is True
+    assert row["provides_tools"] == ["demo_tool"]
+    assert row["provides_hooks"] == ["on_session_start"]
+    assert row["requires_env"] == ["DEMO_API_KEY"]
+    assert row["missing_env"] == ["DEMO_API_KEY"]
+
+
+def test_dashboard_toggle_normalizes_aliases_and_rejects_provider_managed(monkeypatch):
+    from hermes_cli import plugins_cmd
+
+    manifest = SimpleNamespace(
+        name="web-firecrawl",
+        key="web/firecrawl",
+        kind="backend",
+    )
+    enabled = {"firecrawl", "web-firecrawl"}
+    disabled = {"web-firecrawl"}
+    saved: dict[str, set] = {}
+    monkeypatch.setattr(plugins_cmd, "_resolve_plugin_manifest", lambda _name: manifest)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: saved.__setitem__("enabled", set(value)))
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: saved.__setitem__("disabled", set(value)))
+
+    result = plugins_cmd.dashboard_set_agent_plugin_enabled("firecrawl", enabled=True)
+
+    assert result == {"ok": True, "name": "web/firecrawl", "unchanged": False}
+    assert saved["enabled"] == {"web/firecrawl"}
+    assert saved["disabled"] == set()
+
+    manifest.kind = "model-provider"
+    rejected = plugins_cmd.dashboard_set_agent_plugin_enabled("web/firecrawl", enabled=False)
+    assert rejected["ok"] is False
+    assert "provider settings" in rejected["error"]
+
+
+def test_dashboard_remove_cleans_plugin_directory_and_config(tmp_path, monkeypatch):
+    from hermes_cli import plugins, plugins_cmd
+
+    bundled = tmp_path / "bundled"
+    user = tmp_path / "plugins"
+    plugin_dir = _write_plugin(user, "observability/sample", name="sample-plugin")
+    config_path = Path(plugins_cmd.get_hermes_home()) / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump({
+            "plugins": {
+                "enabled": ["observability/sample", "sample", "sample-plugin", "keep"],
+                "disabled": ["sample-plugin", "keep-disabled"],
+                "entries": {
+                    "observability/sample": {"allow_tool_override": True},
+                    "sample-plugin": {"setting": True},
+                    "keep": {"setting": True},
+                },
+            }
+        }),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(plugins, "get_bundled_plugins_dir", lambda: bundled)
+    monkeypatch.setattr(plugins.importlib.metadata, "entry_points", lambda: [])
+    monkeypatch.setattr(plugins_cmd, "_plugins_dir", lambda: user)
+
+    result = plugins_cmd.dashboard_remove_user_plugin("observability/sample")
+
+    assert result == {"ok": True, "name": "observability/sample"}
+    assert not plugin_dir.exists()
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert config["plugins"]["enabled"] == ["keep"]
+    assert config["plugins"]["disabled"] == ["keep-disabled"]
+    assert config["plugins"]["entries"] == {"keep": {"setting": True}}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2464,10 +2464,20 @@ export interface PluginManifestResponse {
 
 export interface HubAgentPluginRow {
   name: string;
+  key?: string;
+  kind?: "standalone" | "backend" | "exclusive" | "platform" | "model-provider";
+  author?: string;
   version: string;
   description: string;
   source: string;
   runtime_status: "disabled" | "enabled" | "inactive";
+  config_status?: "enabled" | "disabled" | "not-enabled" | "auto" | "provider-managed";
+  effective_status?: "enabled" | "disabled" | "inactive" | "auto-active" | "provider-managed";
+  can_toggle?: boolean;
+  provides_tools?: string[];
+  provides_hooks?: string[];
+  requires_env?: string[];
+  missing_env?: string[];
   has_dashboard_manifest: boolean;
   dashboard_manifest: PluginManifestResponse | null;
   path: string;

--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -926,7 +926,8 @@ function PluginRowCard(props: PluginRowCardProps) {
 
   const tabPath = dm?.tab && !dm.tab.hidden ? dm.tab.override ?? dm.tab.path : null;
 
-  const busy = rowBusy === row.name;
+  const pluginKey = row.key || row.name;
+  const busy = rowBusy === pluginKey;
   const [confirmRemove, setConfirmRemove] = useState(false);
 
   const badgeTone =
@@ -964,14 +965,16 @@ function PluginRowCard(props: PluginRowCardProps) {
           </div>
 
           <div className="flex flex-wrap items-center gap-2 shrink-0">
-            {row.runtime_status === "enabled" ? (
+            {row.can_toggle === false ? (
+              <Badge tone="outline">provider managed</Badge>
+            ) : row.runtime_status === "enabled" ? (
               <Button
                 disabled={busy}
                 ghost
                 size="sm"
                 onClick={() => {
-                  void setRuntimeLoading(row.name, async () => {
-                    await api.disableAgentPlugin(row.name);
+                  void setRuntimeLoading(pluginKey, async () => {
+                    await api.disableAgentPlugin(pluginKey);
                     showToast(t.pluginsPage.disableRuntime, "success");
                   });
                 }}
@@ -984,8 +987,8 @@ function PluginRowCard(props: PluginRowCardProps) {
                 ghost
                 size="sm"
                 onClick={() => {
-                  void setRuntimeLoading(row.name, async () => {
-                    await api.enableAgentPlugin(row.name);
+                  void setRuntimeLoading(pluginKey, async () => {
+                    await api.enableAgentPlugin(pluginKey);
                     showToast(t.pluginsPage.enableRuntime, "success");
                   });
                 }}
@@ -1015,8 +1018,8 @@ function PluginRowCard(props: PluginRowCardProps) {
                 ghost
                 size="sm"
                 onClick={() => {
-                  void setRuntimeLoading(row.name, async () => {
-                    await api.updateAgentPlugin(row.name);
+                  void setRuntimeLoading(pluginKey, async () => {
+                    await api.updateAgentPlugin(pluginKey);
                     showToast(t.pluginsPage.updateGit, "success");
                   });
                 }}
@@ -1033,8 +1036,8 @@ function PluginRowCard(props: PluginRowCardProps) {
                 size="sm"
                 title={row.user_hidden ? t.pluginsPage.showInSidebar : t.pluginsPage.hideFromSidebar}
                 onClick={() => {
-                  void setRuntimeLoading(row.name, async () => {
-                    await api.setPluginVisibility(row.name, !row.user_hidden);
+                  void setRuntimeLoading(pluginKey, async () => {
+                    await api.setPluginVisibility(pluginKey, !row.user_hidden);
                   });
                 }}
               >
@@ -1098,8 +1101,8 @@ function PluginRowCard(props: PluginRowCardProps) {
         onCancel={() => setConfirmRemove(false)}
         onConfirm={() => {
           setConfirmRemove(false);
-          void setRuntimeLoading(row.name, async () => {
-            await api.removeAgentPlugin(row.name);
+          void setRuntimeLoading(pluginKey, async () => {
+            await api.removeAgentPlugin(pluginKey);
             showToast(`${row.name} removed`, "success");
           });
         }}


### PR DESCRIPTION
## 改动

- 提取运行时与 Plugins Hub 共用的只读 manifest 扫描，覆盖 bundled、user、project 和 entrypoint 来源，不导入插件代码。
- 扩充 Plugins Hub 的 canonical key、kind、作者、配置/生效状态、能力、环境变量和可操作性字段，同时保留旧协议字段。
- 统一嵌套 key 的启停、更新和卸载行为，清理历史别名及卸载后的 enabled/disabled/entries 配置。
- 将 Provider 管理型插件保持为只读，并让现有 Core Web 插件页使用 canonical key。

## 影响

CN-Desktop 可以直接复用 Core 接口完成当前 Profile 的插件清单、启停、Git 更新与卸载；状态修改仅对后续新会话生效。扫描路径只读取元数据，不执行第三方插件代码。

## 验证

- `ruff check .`：通过
- Core Web `typecheck`：通过
- Core Web Vitest：59/59 通过
- 插件相关 Python 测试：新增 7/7，关联套件 183/183 通过
- `scripts/run_tests.sh`：完整执行 2,033 个文件，40,939 通过；26 个失败均位于未改动模块，来源为 macOS `/tmp` 解析、缺少 `systemctl`、本机代理及并行 live-system guard
- 与 CN-Desktop 临时 `HERMES_HOME` 联调：发现、安装、启用、新进程加载、禁用、更新、卸载链路通过
