### PR TITLE
style: 修正 v0.19 前端格式

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1882,10 +1882,11 @@ function findGitBash() {
   // no auto-download via PortableGit).
   const candidates = [
     path.join(process.env['ProgramFiles'] || 'C:\\Program Files', 'Git', 'bin', 'bash.exe'),
-    path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe'),
+    path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe')
   ]
 
   const localAppData = process.env.LOCALAPPDATA || ''
+
   if (localAppData) {
     candidates.push(path.join(localAppData, 'Programs', 'Git', 'bin', 'bash.exe'))
   }
@@ -3729,8 +3730,10 @@ async function ensureRuntime(backend) {
         findOnPath('pwsh') ||
         (() => {
           const systemRoot = process.env.SystemRoot || process.env.windir || 'C:\\Windows'
+
           return isExecutableFile(path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'))
         })()
+
       if (!hasPowerShell) {
         throw new Error(
           'PowerShell is required for Hermes on Windows but was not found. ' +

--- a/apps/desktop/electron/windows-hermes-resolution.test.ts
+++ b/apps/desktop/electron/windows-hermes-resolution.test.ts
@@ -9,6 +9,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+
 import { test } from 'vitest'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -66,9 +67,5 @@ test('unwrapWindowsVenvHermesCommand delegates to the probe-before-trust resolve
     /resolveVenvHermesCommand\(command, backendArgs, \{/,
     'unwrap must delegate to the resolver that rejects a broken or partial venv'
   )
-  assert.match(
-    body,
-    /canImportHermesCli,/,
-    'unwrap must inject the real runtime import probe into the resolver'
-  )
+  assert.match(body, /canImportHermesCli,/, 'unwrap must inject the real runtime import probe into the resolver')
 })


### PR DESCRIPTION
## 变更

- 应用主分支自动格式流程生成的 2 个文件纯格式补丁
- 不改变 Windows 原生支持逻辑或回归断言语义

## 原因

Fork 未配置上游专用的 `AUTOFIX_BOT_PAT`，自动任务已推送分支但无法创建 PR，因此手动补建。