### PR TITLE
ci: 更新运行时发布至 Python 3.14

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.14"
 
       - name: Install build deps + agent
         shell: bash

--- a/tests/test_runtime_release_workflow.py
+++ b/tests/test_runtime_release_workflow.py
@@ -8,10 +8,13 @@ that contract so a backend can't silently drop out of the build again — the
 failure mode behind issue #16 (MCP) and the 飞书/钉钉/企微/微信 desktop reports.
 """
 
+import re
 import sys
 from pathlib import Path
 
 import pytest
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -53,6 +56,28 @@ def test_runtime_workflow_installs_cn_desktop_extra():
     cn-desktop is the single source of truth for "what the desktop ships".
     """
     assert 'pip install -e ".[cn-desktop]"' in _workflow_text()
+
+
+def test_runtime_workflow_python_satisfies_project_requirement():
+    """The release builder must run a Python accepted by pyproject.toml."""
+    if tomllib is None:  # pragma: no cover
+        pytest.skip("tomllib unavailable")
+
+    project = tomllib.loads(
+        (_repo_root() / "pyproject.toml").read_text(encoding="utf-8")
+    )["project"]
+    match = re.search(
+        r"python-version:\s*[\"']([^\"']+)[\"']",
+        _workflow_text(),
+    )
+
+    assert match, "release-runtime.yml must configure actions/setup-python"
+    workflow_python = Version(match.group(1))
+    requires_python = SpecifierSet(project["requires-python"])
+    assert workflow_python in requires_python, (
+        f"release-runtime.yml uses Python {workflow_python}, which does not "
+        f"satisfy pyproject.toml requires-python {requires_python}"
+    )
 
 
 def test_cn_desktop_extra_bundles_every_desktop_backend():


### PR DESCRIPTION
## 变更

- 将 runtime 发布构建环境从 Python 3.11 更新到 Python 3.14
- 新增契约测试，确保 workflow 的 Python 版本始终满足 `pyproject.toml` 的 `requires-python`

## 根因

v0.19 将最低 Python 版本提高到 `>=3.14`，但 `release-runtime.yml` 仍固定使用 3.11，导致 Windows、macOS 双架构和 Linux 四个构建在安装项目时同时失败。

## 影响

修复后可重新发布 `runtime-v0.19.0-cn.1`，不改变 runtime 产品逻辑。

## 验证

- `pytest tests/test_runtime_release_workflow.py -q`：12 passed
- `ruff check tests/test_runtime_release_workflow.py`
- workflow YAML 解析与 `git diff --check`