### PR TITLE
fix: 补齐桌面冻结运行时资源打包

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -148,10 +148,24 @@ jobs:
           # Build tooling
           pip install pyinstaller==6.* cryptography
 
-      - name: Set up Node.js (build TUI bundle)
+      - name: Set up Node.js (build web dashboard + TUI bundle)
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
+
+      - name: Install Node.js workspace deps
+        shell: bash
+        run: npm ci
+
+      - name: Build web dashboard
+        shell: bash
+        run: |
+          # The desktop runtime serves the dashboard/API bundle from
+          # hermes_cli/web_dist. Build it before PyInstaller so collect-data
+          # includes the actual SPA instead of shipping an empty backend-only
+          # runtime (issue #116).
+          npm --workspace web run build
+          test -f hermes_cli/web_dist/index.html || { echo "::error::hermes_cli/web_dist/index.html not built" >&2; exit 1; }
 
       - name: Build embedded TUI bundle
         shell: bash
@@ -162,8 +176,8 @@ jobs:
           # runtime payload below so the frozen runtime launches it without a
           # ui-tui/ source checkout. Mirrors the PyPI wheel pipeline
           # (upload_to_pypi.yml). See FORK_NOTES P-032.
-          cd ui-tui && npm ci && npm run build
-          test -f dist/entry.js || { echo "::error::ui-tui/dist/entry.js not built" >&2; exit 1; }
+          npm --workspace ui-tui run build
+          test -f ui-tui/dist/entry.js || { echo "::error::ui-tui/dist/entry.js not built" >&2; exit 1; }
 
       - name: Verify platform backends importable (build env)
         shell: bash
@@ -178,7 +192,8 @@ jobs:
           for m in ("mcp", "lark_oapi", "dingtalk_stream", "alibabacloud_dingtalk",
                     "alibabacloud_tea_openapi", "alibabacloud_tea_util",
                     "aiohttp", "qrcode", "defusedxml", "certifi", "typer",
-                    "hindsight_client", "hindsight_client_api", "aiohttp_retry"):
+                    "hindsight_client", "hindsight_client_api", "aiohttp_retry",
+                    "ddgs", "exa_py", "firecrawl", "parallel"):
               try:
                   importlib.import_module(m)
               except Exception as e:
@@ -198,6 +213,24 @@ jobs:
           import plugins.platforms.wecom.adapter as wcm
           import plugins.platforms.wecom.callback_adapter as wc
           import gateway.platforms.weixin as wx
+          for m in (
+              "tools.computer_use_tool",
+              "tools.computer_use.tool",
+              "tools.computer_use.doctor",
+              "tools.computer_use.cua_backend",
+              "plugins.web.brave_free",
+              "plugins.web.ddgs",
+              "plugins.web.exa",
+              "plugins.web.firecrawl",
+              "plugins.web.parallel",
+              "plugins.web.searxng",
+              "plugins.web.tavily",
+              "plugins.web.xai",
+          ):
+              try:
+                  importlib.import_module(m)
+              except Exception as e:
+                  missing.append(f"{m}: {type(e).__name__}: {e}")
           flags = {
               "feishu.FEISHU_AVAILABLE": fs.FEISHU_AVAILABLE,
               "dingtalk.DINGTALK_STREAM_AVAILABLE": dt.DINGTALK_STREAM_AVAILABLE,
@@ -257,6 +290,12 @@ jobs:
             --collect-submodules pydantic \
             --collect-submodules anthropic \
             --collect-submodules mcp \
+            --collect-submodules tools \
+            --collect-submodules plugins.web \
+            --collect-submodules ddgs \
+            --collect-submodules exa_py \
+            --collect-submodules firecrawl \
+            --collect-submodules parallel \
             --collect-submodules lark_oapi \
             --collect-submodules dingtalk_stream \
             --collect-submodules alibabacloud_dingtalk \
@@ -299,6 +338,10 @@ jobs:
             --copy-metadata pydantic \
             --copy-metadata anthropic \
             --copy-metadata mcp \
+            --copy-metadata ddgs \
+            --copy-metadata exa-py \
+            --copy-metadata firecrawl-py \
+            --copy-metadata parallel-web \
             --copy-metadata typer \
             --copy-metadata hindsight-client \
             --copy-metadata aiohttp-retry \
@@ -376,6 +419,32 @@ jobs:
           echo "Staged node + TUI into dist/$NAME:"
           ls -la "$dest"
 
+      - name: Stage bundled plugin/tool resources into payload
+        shell: bash
+        run: |
+          # PyInstaller's module graph makes code importable, but several
+          # Hermes discovery paths intentionally inspect files on disk
+          # (tool shims, plugin manifests, provider.py). Stage the declared
+          # Desktop runtime resources into _internal so the frozen runtime's
+          # advertised tool/plugin inventory matches the payload.
+          NAME="hermes-agent-cn-runtime-${{ matrix.platform }}-${{ matrix.arch }}"
+          internal="dist/$NAME/_internal"
+          mkdir -p "$internal/tools" "$internal/plugins"
+          rm -rf "$internal/tools/computer_use" "$internal/plugins/web"
+          cp tools/__init__.py "$internal/tools/__init__.py"
+          cp tools/computer_use_tool.py "$internal/tools/computer_use_tool.py"
+          cp -R tools/computer_use "$internal/tools/computer_use"
+          cp plugins/__init__.py "$internal/plugins/__init__.py"
+          cp -R plugins/web "$internal/plugins/web"
+
+          test -f "$internal/tools/computer_use_tool.py" || { echo "::error::missing computer_use tool shim" >&2; exit 1; }
+          test -f "$internal/tools/computer_use/tool.py" || { echo "::error::missing computer_use package" >&2; exit 1; }
+          for p in brave_free ddgs exa firecrawl parallel searxng tavily xai; do
+            test -f "$internal/plugins/web/$p/__init__.py" || { echo "::error::missing web plugin $p __init__.py" >&2; exit 1; }
+            test -f "$internal/plugins/web/$p/provider.py" || { echo "::error::missing web plugin $p provider.py" >&2; exit 1; }
+            test -f "$internal/plugins/web/$p/plugin.yaml" || { echo "::error::missing web plugin $p plugin.yaml" >&2; exit 1; }
+          done
+
       - name: Normalize macOS framework layout
         if: matrix.platform == 'darwin'
         shell: bash
@@ -448,7 +517,8 @@ jobs:
                      alibabacloud_tea darabonba_core requests_toolbelt \
                      aiohttp websockets apscheduler aiofiles qrcode pypng \
                      defusedxml cryptography pycryptodome certifi \
-                     hindsight_client aiohttp_retry; do
+                     hindsight_client aiohttp_retry ddgs exa_py firecrawl_py \
+                     parallel_web; do
             if [[ -z "$(find "$internal" -maxdepth 1 -type d -name "${pkg}-*.dist-info" -print -quit)" ]]; then
               echo "::error::Frozen runtime is missing ${pkg} package metadata" >&2
               find "dist/$NAME" -maxdepth 3 -type d -iname "${pkg}*" -print >&2
@@ -473,11 +543,29 @@ jobs:
           fi
           python -c "import json,sys; d=json.load(open(sys.argv[1])); assert isinstance(d, dict) and d, 'snapshot empty'; print('models.dev snapshot OK:', len(d), 'providers')" "$snap"
 
+      - name: Verify frozen runtime resources
+        shell: bash
+        run: |
+          NAME="hermes-agent-cn-runtime-${{ matrix.platform }}-${{ matrix.arch }}"
+          root="dist/$NAME"
+          internal="$root/_internal"
+
+          test -f "$internal/hermes_cli/web_dist/index.html" || { echo "::error::missing hermes_cli/web_dist/index.html" >&2; exit 1; }
+          test -f "$internal/tools/computer_use_tool.py" || { echo "::error::missing tools/computer_use_tool.py" >&2; exit 1; }
+          test -f "$internal/tools/computer_use/tool.py" || { echo "::error::missing tools/computer_use/tool.py" >&2; exit 1; }
+          for p in brave_free ddgs exa firecrawl parallel searxng tavily xai; do
+            for f in __init__.py provider.py plugin.yaml; do
+              test -f "$internal/plugins/web/$p/$f" || { echo "::error::missing plugins/web/$p/$f" >&2; exit 1; }
+            done
+          done
+
       - name: Smoke-test the binary
         shell: bash
         run: |
           NAME="hermes-agent-cn-runtime-${{ matrix.platform }}-${{ matrix.arch }}"
           "./dist/$NAME/$NAME${{ matrix.ext }}" dashboard --help
+          "./dist/$NAME/$NAME${{ matrix.ext }}" tools list --platform cli
+          "./dist/$NAME/$NAME${{ matrix.ext }}" computer-use status
 
       - name: Verify bundled Node runtime + TUI
         shell: bash

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -133,6 +133,21 @@ describe('ModelMenuPanel provider collapse', () => {
     expect(content.queryByText('Deepseek Chat')).not.toBeNull()
   })
 
+  it('surfaces backend provider warnings next to the affected provider', async () => {
+    getGlobalModelOptions.mockResolvedValueOnce({
+      providers: [
+        {
+          ...DEEPSEEK_PROVIDER,
+          warning: 'Live model discovery is unavailable; showing bundled fallback models.'
+        }
+      ]
+    })
+    const { content } = renderPanel()
+
+    await content.findByText('DeepSeek')
+    expect(content.queryByText('Live model discovery is unavailable; showing bundled fallback models.')).not.toBeNull()
+  })
+
   it('collapses provider models when header is clicked', async () => {
     const { content } = renderPanel()
 

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -266,6 +266,11 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
                   )}
                   {group.provider.name}
                 </DropdownMenuItem>
+                {!collapsed && group.provider.warning ? (
+                  <DropdownMenuItem className={cn(dropdownMenuRow, 'text-(--ui-text-tertiary)')} disabled>
+                    {group.provider.warning}
+                  </DropdownMenuItem>
+                ) : null}
                 {!collapsed &&
                   group.families.map(family => {
                     // The active id may be the base or its -fast sibling; either

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -296,6 +296,7 @@ export interface ModelOptionProvider {
   is_current?: boolean
   models?: string[]
   name: string
+  source?: string
   slug: string
   total_models?: number
   warning?: string

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1900,6 +1900,9 @@ def list_authenticated_providers(
     seen_slugs: set = set()  # lowercase-normalized to catch case variants (#9545)
     _current_provider_norm = str(current_provider or "").strip().lower()
     _current_base_url_norm = str(current_base_url or "").strip().rstrip("/").lower()
+    fallback_catalog_warning = (
+        "Live model discovery is unavailable; showing bundled fallback models."
+    )
 
     def _can_probe_custom_provider(*, row_is_current: bool) -> bool:
         return bool(probe_custom_providers or (probe_current_custom_provider and row_is_current))
@@ -2119,10 +2122,13 @@ def list_authenticated_providers(
         # disk caching to keep the picker open snappy. Falls back to the
         # curated static list when the live fetcher returns nothing.
         model_ids = cached_provider_model_ids(hermes_id)
+        fallback_warning = ""
         if not model_ids:
             model_ids = curated.get(hermes_id, [])
             if hermes_id in _MODELS_DEV_PREFERRED:
                 model_ids = _merge_with_models_dev(hermes_id, model_ids)
+            if model_ids:
+                fallback_warning = fallback_catalog_warning
         # A providers.<built-in>.models block extends the provider's discovered
         # catalog. Section 3 cannot emit it later because this built-in row owns
         # the slug, so merge declarations here before applying max_models.
@@ -2141,7 +2147,7 @@ def list_authenticated_providers(
         pinfo = _mdev_pinfo(mdev_id)
         display_name = pconfig.name if pconfig and pconfig.name else (pinfo.name if pinfo else mdev_id)
 
-        results.append({
+        row = {
             "slug": slug,
             "name": display_name,
             "is_current": (
@@ -2153,7 +2159,10 @@ def list_authenticated_providers(
             "models": top,
             "total_models": total,
             "source": "built-in",
-        })
+        }
+        if fallback_warning:
+            row["warning"] = fallback_warning
+        results.append(row)
         seen_slugs.add(slug.lower())
         _record_builtin_endpoint(slug)
 
@@ -2251,6 +2260,7 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
+        fallback_warning = ""
         if hermes_slug in {"openai-codex", "copilot", "copilot-acp"}:
             # Use live OAuth-backed discovery so the gateway /model picker
             # matches what the user's authenticated Codex/Copilot backend
@@ -2266,8 +2276,12 @@ def list_authenticated_providers(
             try:
                 _ids = cached_provider_model_ids(hermes_slug)
                 model_ids = _ids if _ids else (curated.get(hermes_slug, []) or curated.get(pid, []))
+                if not _ids and model_ids:
+                    fallback_warning = fallback_catalog_warning
             except Exception:
                 model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
+                if model_ids:
+                    fallback_warning = fallback_catalog_warning
         elif hermes_slug == "nous":
             # Nous serves a large live /v1/models catalog (vendor-prefixed
             # models from many providers, returned alphabetically). The
@@ -2314,13 +2328,15 @@ def list_authenticated_providers(
                 model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
                 if hermes_slug in _MODELS_DEV_PREFERRED:
                     model_ids = _merge_with_models_dev(hermes_slug, model_ids)
+                if model_ids:
+                    fallback_warning = fallback_catalog_warning
         total = len(model_ids)
         if hermes_slug in _UNCAPPED_PICKER_PROVIDERS:
             top = model_ids  # Aggregator: show full catalog regardless of max_models
         else:
             top = model_ids[:max_models] if max_models is not None else model_ids
 
-        results.append({
+        row = {
             "slug": hermes_slug,
             "name": get_label(hermes_slug),
             "is_current": hermes_slug == current_provider or pid == current_provider,
@@ -2328,7 +2344,10 @@ def list_authenticated_providers(
             "models": top,
             "total_models": total,
             "source": "hermes",
-        })
+        }
+        if fallback_warning:
+            row["warning"] = fallback_warning
+        results.append(row)
         seen_slugs.add(pid.lower())
         seen_slugs.add(hermes_slug.lower())
         _record_builtin_endpoint(hermes_slug)
@@ -2392,21 +2411,28 @@ def list_authenticated_providers(
 
         # For bedrock, use live discovery so the list reflects the active
         # region (eu.*, us.*, ap.*) instead of the hardcoded us.* static list.
+        _cp_fallback_warning = ""
         if _cp_config and getattr(_cp_config, "auth_type", "") == "aws_sdk":
             try:
                 _ids = cached_provider_model_ids(_cp.slug)
                 _cp_model_ids = _ids if _ids else curated.get(_cp.slug, [])
+                if not _ids and _cp_model_ids:
+                    _cp_fallback_warning = fallback_catalog_warning
             except Exception:
                 _cp_model_ids = curated.get(_cp.slug, [])
+                if _cp_model_ids:
+                    _cp_fallback_warning = fallback_catalog_warning
         else:
             # Unified pathway — same as sections 1 and 2.
             _cp_model_ids = cached_provider_model_ids(_cp.slug)
             if not _cp_model_ids:
                 _cp_model_ids = curated.get(_cp.slug, [])
+                if _cp_model_ids:
+                    _cp_fallback_warning = fallback_catalog_warning
         _cp_total = len(_cp_model_ids)
         _cp_top = _cp_model_ids[:max_models] if max_models is not None else _cp_model_ids
 
-        results.append({
+        row = {
             "slug": _cp.slug,
             "name": _cp.label,
             "is_current": _cp.slug == current_provider,
@@ -2414,7 +2440,10 @@ def list_authenticated_providers(
             "models": _cp_top,
             "total_models": _cp_total,
             "source": "canonical",
-        })
+        }
+        if _cp_fallback_warning:
+            row["warning"] = _cp_fallback_warning
+        results.append(row)
         seen_slugs.add(_cp.slug.lower())
         _record_builtin_endpoint(_cp.slug)
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1423,17 +1423,17 @@ def _run_post_setup(post_setup_key: str):
         except ImportError:
             _print_info("    Installing ddgs (DuckDuckGo search package)...")
             try:
-                result = _pip_install(["-U", "ddgs", "--quiet"], timeout=300)
+                result = _pip_install(["-U", "ddgs==9.14.4", "--quiet"], timeout=300)
                 if result.returncode == 0:
                     _print_success("    ddgs installed")
                 else:
                     _print_warning("    ddgs install failed:")
                     _print_info(f"      {(result.stderr or '').strip()[:300]}")
-                    _print_info("    Run manually: uv pip install -U ddgs")
+                    _print_info("    Run manually: uv pip install -U ddgs==9.14.4")
                     return
             except subprocess.TimeoutExpired:
                 _print_warning("    ddgs install timed out (>5min)")
-                _print_info("    Run manually: uv pip install -U ddgs")
+                _print_info("    Run manually: uv pip install -U ddgs==9.14.4")
                 return
         _print_info("    No API key required. DuckDuckGo enforces server-side rate limits.")
         _print_info("    Pair with an extract provider if you also need web_extract.")

--- a/plugins/web/brave_free/__init__.py
+++ b/plugins/web/brave_free/__init__.py
@@ -6,7 +6,7 @@ provider class, ``__init__.py::register(ctx)`` registers an instance.
 
 from __future__ import annotations
 
-from plugins.web.brave_free.provider import BraveFreeWebSearchProvider
+from .provider import BraveFreeWebSearchProvider
 
 
 def register(ctx) -> None:

--- a/plugins/web/ddgs/__init__.py
+++ b/plugins/web/ddgs/__init__.py
@@ -7,7 +7,7 @@ results page. No API key required, but the package itself must be installed
 
 from __future__ import annotations
 
-from plugins.web.ddgs.provider import DDGSWebSearchProvider
+from .provider import DDGSWebSearchProvider
 
 
 def register(ctx) -> None:

--- a/plugins/web/exa/__init__.py
+++ b/plugins/web/exa/__init__.py
@@ -7,7 +7,7 @@ caller is async.
 
 from __future__ import annotations
 
-from plugins.web.exa.provider import ExaWebSearchProvider
+from .provider import ExaWebSearchProvider
 
 
 def register(ctx) -> None:

--- a/plugins/web/firecrawl/__init__.py
+++ b/plugins/web/firecrawl/__init__.py
@@ -20,7 +20,7 @@ external code that imports those names from ``tools.web_tools``.
 
 from __future__ import annotations
 
-from plugins.web.firecrawl.provider import FirecrawlWebSearchProvider
+from .provider import FirecrawlWebSearchProvider
 
 
 def register(ctx) -> None:

--- a/plugins/web/parallel/__init__.py
+++ b/plugins/web/parallel/__init__.py
@@ -8,7 +8,7 @@ awaits.
 
 from __future__ import annotations
 
-from plugins.web.parallel.provider import ParallelWebSearchProvider
+from .provider import ParallelWebSearchProvider
 
 
 def register(ctx) -> None:

--- a/plugins/web/searxng/__init__.py
+++ b/plugins/web/searxng/__init__.py
@@ -7,7 +7,7 @@ Search-only — pair with an extract provider (firecrawl/tavily/exa) for
 
 from __future__ import annotations
 
-from plugins.web.searxng.provider import SearXNGWebSearchProvider
+from .provider import SearXNGWebSearchProvider
 
 
 def register(ctx) -> None:

--- a/plugins/web/tavily/__init__.py
+++ b/plugins/web/tavily/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from plugins.web.tavily.provider import TavilyWebSearchProvider
+from .provider import TavilyWebSearchProvider
 
 
 def register(ctx) -> None:

--- a/plugins/web/xai/__init__.py
+++ b/plugins/web/xai/__init__.py
@@ -6,7 +6,7 @@ provider class, ``__init__.py::register(ctx)`` registers an instance.
 
 from __future__ import annotations
 
-from plugins.web.xai.provider import XAIWebSearchProvider
+from .provider import XAIWebSearchProvider
 
 
 def register(ctx) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ anthropic = ["anthropic==0.87.0"]  # CVE-2026-34450, CVE-2026-34452
 exa = ["exa-py==2.10.2"]
 firecrawl = ["firecrawl-py==4.17.0"]
 parallel-web = ["parallel-web==0.4.2"]
+ddgs = ["ddgs==9.14.4"]
 # Image generation backends
 fal = ["fal-client==0.13.1"]
 # Edge TTS — default TTS provider but still optional (users can pick
@@ -328,6 +329,11 @@ cn-desktop = [
   "hermes-agent[web]",        # dashboard: fastapi / uvicorn / starlette
   "hermes-agent[anthropic]",  # native Anthropic transport (MiniMax-CN etc.)
   "hermes-agent[mcp]",        # native MCP client SDK (issue #16)
+  "hermes-agent[computer-use]", # computer_use tool shim + MCP client; cua-driver stays post-install
+  "hermes-agent[exa]",        # bundled web provider (frozen runtime cannot lazy-install)
+  "hermes-agent[firecrawl]",  # bundled web provider (frozen runtime cannot lazy-install)
+  "hermes-agent[parallel-web]", # bundled web provider (frozen runtime cannot lazy-install)
+  "hermes-agent[ddgs]",       # bundled no-key web provider (frozen runtime cannot lazy-install)
   # PyInstaller's --collect-submodules mcp imports mcp.cli during analysis.
   # The mcp package keeps its CLI deps behind the mcp[cli] extra, so the frozen
   # runtime build must install typer explicitly or all platform builds fail.

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -19,6 +19,7 @@ depend on:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 
@@ -329,6 +330,29 @@ def test_list_authenticated_providers_force_fresh_is_keyword_only():
     param = sig.parameters["force_fresh_nous_tier"]
     assert param.kind is inspect.Parameter.KEYWORD_ONLY
     assert param.default is False
+
+
+def test_list_authenticated_providers_warns_when_catalog_falls_back(monkeypatch):
+    """Authenticated rows must mark curated/models.dev fallback catalogs."""
+    from hermes_cli.model_switch import list_authenticated_providers
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+
+    with (
+        patch("agent.models_dev.PROVIDER_TO_MODELS_DEV", {"deepseek": "deepseek"}),
+        patch("agent.models_dev.fetch_models_dev", return_value={"deepseek": {"env": ["DEEPSEEK_API_KEY"]}}),
+        patch("agent.models_dev.get_provider_info", return_value=SimpleNamespace(name="DeepSeek")),
+        patch("hermes_cli.auth.is_runtime_provider_routable", return_value=True),
+        patch("hermes_cli.models.cached_provider_model_ids", return_value=[]),
+        patch("hermes_cli.models._merge_with_models_dev", side_effect=lambda _provider, models: list(models)),
+        patch("hermes_cli.providers.HERMES_OVERLAYS", {}),
+        patch("hermes_cli.models.CANONICAL_PROVIDERS", []),
+    ):
+        rows = list_authenticated_providers(max_models=3)
+
+    deepseek = next(row for row in rows if row["slug"] == "deepseek")
+    assert deepseek["models"]
+    assert "Live model discovery is unavailable" in deepseek["warning"]
 
 
 def test_pricing_uses_cached_nous_tier_by_default():

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+from pathlib import Path
 
 import pytest
 
@@ -70,7 +71,7 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestBundledPluginsRegister:
     """All eight bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_eight_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -85,6 +86,29 @@ class TestBundledPluginsRegister:
             "tavily",
             "xai",
         ]
+
+    def test_plugin_entrypoints_use_package_relative_provider_imports(self) -> None:
+        """PyInstaller can stage bundled plugins at package-relative paths."""
+        root = Path(__file__).resolve().parents[3]
+        for init_file in (root / "plugins" / "web").glob("*/__init__.py"):
+            text = init_file.read_text(encoding="utf-8", errors="replace")
+            assert "from plugins.web." not in text
+            assert "from .provider import " in text
+
+    def test_check_fn_triggers_plugin_discovery_before_availability(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Tool schema gating must see plugin-registered web providers."""
+        import tools.web_tools as web_tools
+        from agent import web_search_registry
+
+        calls: list[str] = []
+
+        monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: calls.append("loaded"))
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": ""})
+        monkeypatch.setattr(web_tools, "_is_backend_available", lambda _backend: False)
+        monkeypatch.setattr(web_search_registry, "list_providers", lambda: [])
+
+        assert web_tools.check_web_api_key() is False
+        assert calls == ["loaded"]
 
     @pytest.mark.parametrize(
         "plugin_name,expected_search,expected_extract",

--- a/tests/test_runtime_release_workflow.py
+++ b/tests/test_runtime_release_workflow.py
@@ -85,7 +85,19 @@ def test_cn_desktop_extra_bundles_every_desktop_backend():
     extra = _cn_desktop_extra()
     blob = "\n".join(extra)
     # Aggregated sub-extras
-    for sub in ("web", "anthropic", "mcp", "feishu", "dingtalk", "wecom"):
+    for sub in (
+        "web",
+        "anthropic",
+        "mcp",
+        "computer-use",
+        "exa",
+        "firecrawl",
+        "parallel-web",
+        "ddgs",
+        "feishu",
+        "dingtalk",
+        "wecom",
+    ):
         assert f"[{sub}]" in blob, f"cn-desktop is missing the {sub} extra"
     # 微信 (weixin) has no dedicated extra — its adapter deps are listed directly
     assert any(e.startswith("aiohttp") for e in extra), "cn-desktop missing aiohttp (微信/feishu/wecom)"
@@ -109,6 +121,51 @@ def test_runtime_workflow_freezes_native_mcp_client():
     assert "--collect-submodules mcp" in workflow
     assert "--copy-metadata mcp" in workflow
     assert "mcp" in _frozen_verify_packages()
+
+
+def test_runtime_workflow_builds_and_verifies_web_dist():
+    """Issue #116: the frozen runtime must ship the dashboard SPA bundle."""
+    workflow = _workflow_text()
+    assert "Build web dashboard" in workflow
+    assert "hermes_cli/web_dist/index.html not built" in workflow
+    assert "--collect-data hermes_cli" in workflow
+    assert "Verify frozen runtime resources" in workflow
+    assert "hermes_cli/web_dist/index.html" in workflow
+
+
+def test_runtime_workflow_freezes_computer_use_tooling():
+    """Issue #106: Desktop-visible computer_use must be importable frozen."""
+    workflow = _workflow_text()
+    assert any("[computer-use]" in e for e in _cn_desktop_extra())
+    assert "--collect-submodules tools" in workflow
+    for mod in (
+        "tools.computer_use_tool",
+        "tools.computer_use.tool",
+        "tools.computer_use.doctor",
+        "tools.computer_use.cua_backend",
+    ):
+        assert mod in workflow
+    assert "tools/computer_use_tool.py" in workflow
+    assert "tools/computer_use/tool.py" in workflow
+    assert "computer-use status" in workflow
+    assert "cua-driver" not in "\n".join(_cn_desktop_extra())
+
+
+def test_runtime_workflow_freezes_web_search_providers():
+    """Issue #111: bundled Web providers and SDK metadata must ship frozen."""
+    workflow = _workflow_text()
+    extra = _cn_desktop_extra()
+    for sub in ("exa", "firecrawl", "parallel-web", "ddgs"):
+        assert any(f"[{sub}]" in e for e in extra), f"cn-desktop missing {sub}"
+    for mod in ("plugins.web", "ddgs", "exa_py", "firecrawl", "parallel"):
+        assert f"--collect-submodules {mod}" in workflow
+    for dist in ("ddgs", "exa-py", "firecrawl-py", "parallel-web"):
+        assert f"--copy-metadata {dist}" in workflow
+    for pkg in ("ddgs", "exa_py", "firecrawl_py", "parallel_web"):
+        assert pkg in _frozen_verify_packages()
+    for plugin in ("brave_free", "ddgs", "exa", "firecrawl", "parallel", "searxng", "tavily", "xai"):
+        assert f"plugins.web.{plugin}" in workflow
+        assert f"plugins/web/$p/plugin.yaml" in workflow
 
 
 def test_runtime_workflow_freezes_im_platform_backends():

--- a/tests/tools/test_web_providers_searxng.py
+++ b/tests/tools/test_web_providers_searxng.py
@@ -322,9 +322,12 @@ class TestCheckWebApiKey:
         monkeypatch.delenv("TAVILY_API_KEY", raising=False)
         monkeypatch.delenv("EXA_API_KEY", raising=False)
         monkeypatch.delenv("SEARXNG_URL", raising=False)
+        monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
         monkeypatch.setattr(web_tools, "check_firecrawl_api_key", lambda: False)
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+        monkeypatch.setattr("tools.xai_http.has_xai_credentials", lambda: False)
         assert web_tools.check_web_api_key() is False
 
 

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -360,8 +360,12 @@ class TestWebToolPolicy:
     _register_providers = staticmethod(register_all_web_providers)
 
     @pytest.fixture(autouse=True)
-    def _populate_web_registry(self):
+    def _populate_web_registry(self, monkeypatch):
         self._register_providers()
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "firecrawl"})
         yield
         from agent.web_search_registry import _reset_for_tests
         _reset_for_tests()

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1048,6 +1048,10 @@ def check_web_api_key() -> bool:
     :func:`_is_backend_available`, which delegates non-legacy names to the
     registry.
     """
+    # check_fn runs before tool dispatch, so registry-backed plugin providers
+    # must be discovered here too. Otherwise the Desktop/frozen runtime can hide
+    # web_search/web_extract even though bundled provider plugins are present.
+    _ensure_web_plugins_loaded()
     # ``or ""``: a null ``web.backend`` value yields None from ``.get``, and
     # ``None.lower()`` would raise. Mirrors ``_get_backend``.
     configured = (_load_web_config().get("backend") or "").lower().strip()
@@ -1057,20 +1061,28 @@ def check_web_api_key() -> bool:
     # unlike _get_backend() the probe order is irrelevant.
     if any(_is_backend_available(backend) for backend in _LEGACY_WEB_BACKENDS):
         return True
-    # Any plugin-registered provider the registry considers active for either
-    # capability. Delegating to the registry's own availability-filtered
-    # resolvers keeps a single authority for "is a custom provider usable"
-    # rather than re-implementing the walk here.
+    # Any non-legacy plugin-registered provider that reports itself available.
+    # Legacy providers are already covered above through the hardcoded probes;
+    # do not let the registry re-evaluate them or a bundled/free provider like
+    # ddgs can bypass test and setup-time availability shims.
     try:
-        from agent.web_search_registry import (
-            get_active_search_provider,
-            get_active_extract_provider,
-        )
+        from agent.web_search_registry import list_providers
 
-        return (
-            get_active_search_provider() is not None
-            or get_active_extract_provider() is not None
-        )
+        for provider in list_providers():
+            if provider.name in _LEGACY_WEB_BACKENDS:
+                continue
+            if not (provider.supports_search() or provider.supports_extract()):
+                continue
+            try:
+                if provider.is_available():
+                    return True
+            except Exception as provider_exc:  # noqa: BLE001
+                logger.debug(
+                    "web provider %r.is_available() raised: %s",
+                    provider.name,
+                    provider_exc,
+                )
+        return False
     except Exception as exc:  # noqa: BLE001 — registry optional; never fatal
         logger.debug("web provider registry availability check failed: %s", exc)
         return False

--- a/uv.lock
+++ b/uv.lock
@@ -484,6 +484,24 @@ wheels = [
 ]
 
 [[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/e1/298c2ddf786bb7347a1cd71d63a347a79e5712a7c0cba9e3c3458ebd976f/brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21", size = 863080, upload-time = "2025-11-05T18:38:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0c/aac98e286ba66868b2b3b50338ffbd85a35c7122e9531a73a37a29763d38/brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac", size = 445453, upload-time = "2025-11-05T18:38:46.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f1/0ca1f3f99ae300372635ab3fe2f7a79fa335fee3d874fa7f9e68575e0e62/brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e", size = 1528168, upload-time = "2025-11-05T18:38:47.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a6/2ebfc8f766d46df8d3e65b880a2e220732395e6d7dc312c1e1244b0f074a/brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7", size = 1627098, upload-time = "2025-11-05T18:38:48.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/0976d5b097ff8a22163b10617f76b2557f15f0f39d6a0fe1f02b1a53e92b/brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63", size = 1419861, upload-time = "2025-11-05T18:38:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/d76df7176a2ce7616ff94c1fb72d307c9a30d2189fe877f3dd99af00ea5a/brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b", size = 1484594, upload-time = "2025-11-05T18:38:50.655Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/93/14cf0b1216f43df5609f5b272050b0abd219e0b54ea80b47cef9867b45e7/brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361", size = 1593455, upload-time = "2025-11-05T18:38:51.624Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
 name = "brotlicffi"
 version = "1.2.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -860,6 +878,22 @@ wheels = [
 ]
 
 [[package]]
+name = "ddgs"
+version = "9.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "fake-useragent" },
+    { name = "httpx", extra = ["brotli", "http2", "socks"] },
+    { name = "lxml" },
+    { name = "primp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/24/9d29eeb7dd4852c27c3673adcaf30c4dc55ced76b303c1fbb792ce7cae52/ddgs-9.14.4.tar.gz", hash = "sha256:f7b118a2b709a9e9c04a1dca6e96b98c25d4dfaca1a4b0a244d74454fcca48ef", size = 59742, upload-time = "2026-05-15T06:53:45.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/5f/32de4d99220eb559b7b1cd1c529a1856efa8097f7a3e10b6c207aa95e36c/ddgs-9.14.4-py3-none-any.whl", hash = "sha256:acb084c34bf1110c974caf7e5e5a2c1973beb4bd9e170bfd191fe5ed2d2b2d6c", size = 70638, upload-time = "2026-05-15T06:53:44.761Z" },
+]
+
+[[package]]
 name = "debugpy"
 version = "1.8.20"
 source = { registry = "https://pypi.org/simple" }
@@ -1028,6 +1062,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fe/4f/f06a6f277d668f143e330fe503b0027cc5fed753b22c3e161f8cbbccdf65/exa_py-2.10.2.tar.gz", hash = "sha256:f781f30b199f1102333384728adae64bb15a6bbcabfa97e91fd705f90acffc45", size = 53792, upload-time = "2026-03-26T20:29:35.764Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/bc/7a34e904a415040ba626948d0b0a36a08cd073f12b13342578a68331be3c/exa_py-2.10.2-py3-none-any.whl", hash = "sha256:ecb2a7581f4b7a8aeb6b434acce1bbc40f92ed1d4126b2aa6029913acd904a47", size = 72248, upload-time = "2026-03-26T20:29:37.306Z" },
+]
+
+[[package]]
+name = "fake-useragent"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/43/948d10bf42735709edb5ae51e23297d034086f17fc7279fef385a7acb473/fake_useragent-2.2.0.tar.gz", hash = "sha256:4e6ab6571e40cc086d788523cf9e018f618d07f9050f822ff409a4dfe17c16b2", size = 158898, upload-time = "2025-04-14T15:32:19.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/37/b3ea9cd5558ff4cb51957caca2193981c6b0ff30bd0d2630ac62505d99d0/fake_useragent-2.2.0-py3-none-any.whl", hash = "sha256:67f35ca4d847b0d298187443aaf020413746e56acd985a611908c73dba2daa24", size = 161695, upload-time = "2025-04-14T15:32:17.732Z" },
 ]
 
 [[package]]
@@ -1443,12 +1486,16 @@ cn-desktop = [
     { name = "alibabacloud-dingtalk" },
     { name = "anthropic" },
     { name = "cryptography" },
+    { name = "ddgs" },
     { name = "defusedxml" },
     { name = "dingtalk-stream" },
+    { name = "exa-py" },
     { name = "fastapi" },
+    { name = "firecrawl-py" },
     { name = "hindsight-client" },
     { name = "lark-oapi" },
     { name = "mcp" },
+    { name = "parallel-web" },
     { name = "python-multipart" },
     { name = "qrcode" },
     { name = "starlette" },
@@ -1461,6 +1508,9 @@ computer-use = [
 ]
 daytona = [
     { name = "daytona" },
+]
+ddgs = [
+    { name = "ddgs" },
 ]
 dev = [
     { name = "debugpy" },
@@ -1630,6 +1680,7 @@ requires-dist = [
     { name = "cryptography", specifier = "==46.0.7" },
     { name = "cryptography", marker = "extra == 'cn-desktop'", specifier = "==46.0.7" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.155.0" },
+    { name = "ddgs", marker = "extra == 'ddgs'", specifier = "==9.14.4" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = "==1.8.20" },
     { name = "defusedxml", marker = "extra == 'wecom'", specifier = "==0.7.1" },
     { name = "dingtalk-stream", marker = "extra == 'dingtalk'", specifier = "==0.24.3" },
@@ -1652,10 +1703,14 @@ requires-dist = [
     { name = "hermes-agent", extras = ["anthropic"], marker = "extra == 'cn-desktop'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'termux'" },
+    { name = "hermes-agent", extras = ["computer-use"], marker = "extra == 'cn-desktop'" },
     { name = "hermes-agent", extras = ["cron"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["cron"], marker = "extra == 'termux'" },
+    { name = "hermes-agent", extras = ["ddgs"], marker = "extra == 'cn-desktop'" },
     { name = "hermes-agent", extras = ["dingtalk"], marker = "extra == 'cn-desktop'" },
+    { name = "hermes-agent", extras = ["exa"], marker = "extra == 'cn-desktop'" },
     { name = "hermes-agent", extras = ["feishu"], marker = "extra == 'cn-desktop'" },
+    { name = "hermes-agent", extras = ["firecrawl"], marker = "extra == 'cn-desktop'" },
     { name = "hermes-agent", extras = ["google"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["google"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["hindsight"], marker = "extra == 'cn-desktop'" },
@@ -1665,6 +1720,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["mcp"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["mcp"], marker = "extra == 'cn-desktop'" },
     { name = "hermes-agent", extras = ["mcp"], marker = "extra == 'termux'" },
+    { name = "hermes-agent", extras = ["parallel-web"], marker = "extra == 'cn-desktop'" },
     { name = "hermes-agent", extras = ["pty"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["pty"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["sms"], marker = "extra == 'all'" },
@@ -1751,7 +1807,7 @@ requires-dist = [
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
     { name = "zstandard", specifier = ">=0.25.0" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "supermemory", "mem0", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all", "cn-desktop"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "ddgs", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "supermemory", "mem0", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all", "cn-desktop"]
 
 [[package]]
 name = "hf-xet"
@@ -1872,6 +1928,10 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+brotli = [
+    { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
+    { name = "brotlicffi", marker = "platform_python_implementation != 'CPython'" },
+]
 http2 = [
     { name = "h2" },
 ]
@@ -2051,6 +2111,50 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/ad/1ab04db5d549ad1a7a2cd33682b1c38dee1d65019cb24fd7a23270e6337d/lark_oapi-1.6.8-py3-none-any.whl", hash = "sha256:9b443a5d47a7d204dd42dc40896c8b75087cc35788e45c48c140806d7df7e5e8", size = 7798300, upload-time = "2026-06-02T07:40:05.492Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
 ]
 
 [[package]]
@@ -2777,6 +2881,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7e/14/edebfb265f7141f4681b7f2d1cd8dea2621010a9ad7d3819831db2037f13/posthog-7.21.0.tar.gz", hash = "sha256:182ab7572748ae5199cb72c281a3549b70920cb8071e037ff6e07acbfae80876", size = 308788, upload-time = "2026-06-26T15:57:01.727Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/07/ca761fd0e3b23e9bfeaaeeffa5df4c235fd0c5086d89934553583e6902f3/posthog-7.21.0-py3-none-any.whl", hash = "sha256:11dca1e9772bedcb6721751fb0945fa8dcddbf9a4e72e2430483b53cdb8d1ec0", size = 370932, upload-time = "2026-06-26T15:56:59.844Z" },
+]
+
+[[package]]
+name = "primp"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/4b/7efa54f38da7de8df6b70dfed173bb41a52b740b144e4be24c1172db4209/primp-1.3.1.tar.gz", hash = "sha256:b04a5941bf9c876d011c5defaf5a25be093d56e7270b8da52c9788b9df2a829a", size = 1360029, upload-time = "2026-05-23T17:39:25.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/80/c4885a783a7493e396d89a592ba19fce63ef6bd6ad47230924a884a30ec0/primp-1.3.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:27b87e6370045a0c65c0e4dfdfacbfe637387d05673ce8ddcce400263f7c27f0", size = 5123967, upload-time = "2026-05-23T17:39:08.586Z" },
+    { url = "https://files.pythonhosted.org/packages/58/c1/c965cc23f96a364803d44b4331f33e4465bb6f269add37e39d0ad77ffe33/primp-1.3.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:27a8804eb9a3f641f379ee2b443591428cf85c898816e93d04d3e7b6f229ebcb", size = 4743059, upload-time = "2026-05-23T17:39:15.536Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/99/f4248d8d833d43fd8ba78208f2f4bf7fba7d3aec8c516090a95d18d6f550/primp-1.3.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:862974796552a51af8e276bb19c5d5e189168ab8bad216aef7ce3726a8d3b1dd", size = 5100121, upload-time = "2026-05-23T17:39:04.64Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ad/519e32e0184763e1a76c9321fdeac0bb9b30bf85746f12058feec0cc4a27/primp-1.3.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ceb24198994799706f4020a00173ba9c1b491aa9805b1e014d87946677bc3c5d", size = 4738042, upload-time = "2026-05-23T17:39:35.967Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7b/723cb40694b47ec79a142ed8492835c0ecae9fef7acbed014f04b018d1de/primp-1.3.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3298b8afcf0a88ba6622bfc18e78aeb11afbb7d5afa4774f24acf7491f54a2d", size = 5001773, upload-time = "2026-05-23T17:39:03.01Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/80a2e3bdab1c51d738b82ea210a5ab93986b443c561e792e42cae296ec10/primp-1.3.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6b8d38c5a6d0a863274cbcae9678f265fcdcead3c20d12d152244e88f5f2186b", size = 5334228, upload-time = "2026-05-23T17:39:24.214Z" },
+    { url = "https://files.pythonhosted.org/packages/19/70/c95b8054c7d1fe2d84226ec60a5f48ce6c95a08b7c8b1702d7742082f444/primp-1.3.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96f831c78ddb5900873f51e294bf9bbb4bbfdac3a2f39ce4023f8c558d299332", size = 5157269, upload-time = "2026-05-23T17:38:48.142Z" },
+    { url = "https://files.pythonhosted.org/packages/34/bb/9b66986b7ecf2eff987134cd94bde533142e3085d6f67531f1a369ceaaae/primp-1.3.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:329d0c320841f65b39d80801d8bae126732b84ec1094ca17b14fda0bda1b20ff", size = 5347438, upload-time = "2026-05-23T17:39:17.405Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/5d127748d06f3c6a3367f3c4974e45b98cda61cd28ea79ef91ad3fe9e093/primp-1.3.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6c3c67670c38a03e9e8da45b212243d35afc8efa018317c46ecdce47f05329d1", size = 5264862, upload-time = "2026-05-23T17:39:20.625Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f3/1aac229425cac142c48418e2de9f70597161ea936543b5e3c9e7476e1921/primp-1.3.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:9409a31028a8c62a609d389554ad4f5339aad075130300cd443beef0336d7179", size = 4969889, upload-time = "2026-05-23T17:39:22.412Z" },
+    { url = "https://files.pythonhosted.org/packages/38/86/a94d6e6166139c76ae42eb941328679309ca85139e8753d639657a24474c/primp-1.3.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:88ca36c2bd1b7c64b96ad07ca367d2d111ac8e9670549be5f232da8bf795d21e", size = 5082679, upload-time = "2026-05-23T17:39:28.411Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/61/21d297db575ed660c6aaf35c9014c1874ace45d6dcb79d1a4d3d2608bffb/primp-1.3.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:74d13800b501aa003fb05c263d38f8d61656c83a60b2951046c0fc412bc73976", size = 5605392, upload-time = "2026-05-23T17:39:38.007Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d6/9262a7ebb1d980a2db0cd505bb902bb3e66acd8a1cb763a4c2921f2f6a5b/primp-1.3.1-cp310-abi3-win32.whl", hash = "sha256:09ada1752629fe89d7b128beeb59cb641f404af462e24177ba36aed1cf322299", size = 4270373, upload-time = "2026-05-23T17:38:44.98Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/68/f0c6a60fadff0c185aef232b951a6fa4bbb64511facc48d34734db14f16f/primp-1.3.1-cp310-abi3-win_amd64.whl", hash = "sha256:c0d1e294466cd5ec7ef173eedf8df25cbdc050138d40447a906e92b8553e7765", size = 4661498, upload-time = "2026-05-23T17:39:32.213Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/1d/232a52abc77384ac66b9c1741691dec3659b1207bb6c5e55c1e9b59d22f1/primp-1.3.1-cp310-abi3-win_arm64.whl", hash = "sha256:43304cb41cbb46f361de49faf1cbdba57f969f628c9297239c7ed8ef0cac420f", size = 4624481, upload-time = "2026-05-23T17:38:42.724Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/0b/34333b26c533c3122b936dad829f0a6e04f32065d39673c92b157d97aa16/primp-1.3.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:72249a4540d0a8965f36eb9a86cd16801d1c7e8dac2f0b0fa23a0a5a03402d36", size = 5116098, upload-time = "2026-05-23T17:38:55.219Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/56/7fe14708adf9a5cb5d6a15ad840a3de036cebfaf20692a5bc3b72e188a73/primp-1.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:db4e2eaa5707e47899eeba6026f420f9b0108a28c08d63f1826d0cab8d50f06f", size = 4736300, upload-time = "2026-05-23T17:38:51.792Z" },
+    { url = "https://files.pythonhosted.org/packages/31/cb/521a8c18e8808a75450b6e91dc62cc1149c0178b7d4a8697d3f9b73fa385/primp-1.3.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d62e7609c98b4bc99c9cecc47f16f332fb8fe1a023002176267b0043dedad0c7", size = 5093823, upload-time = "2026-05-23T17:38:50.059Z" },
+    { url = "https://files.pythonhosted.org/packages/57/84/90f776fe46aeb0e3b86df72c674c0651326dd6a61846dd86bddbabe903ac/primp-1.3.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3d692e912c2b25271163ba7719df0afdb733a7e7c3073c9094e9001882463543", size = 4734511, upload-time = "2026-05-23T17:39:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/d9bfbc0df0394f18a98b512a65f4bcf3dd7d17bd871937127e1ce4549172/primp-1.3.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c08693517dc160a12c0f9e2565c5319173cef738893a303ff2fb28ecccbd84d", size = 4999315, upload-time = "2026-05-23T17:39:12.061Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d8/5a986957ee1874d08567d7749668cd78a063048d47d6e46a874742b7fed1/primp-1.3.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d134ebfa31adc619e4e48289fe3e7eebc8310141560e6a6a04269cc94893d9ab", size = 5329375, upload-time = "2026-05-23T17:39:30.307Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/1d/321cac9902cc3992174ed530719141a0da2e426f54f8a90b7b971571d104/primp-1.3.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48e27e7c0e015a6de495cf79c0c8d599ba5f69d091af31572bec2de020522d9c", size = 5140921, upload-time = "2026-05-23T17:38:53.528Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/19/ccbe6b67e0e91beb5c9d5cf804354225d5a3a7a9adf84fee3d6acc53febd/primp-1.3.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c3d682df08c1b1f37b1f66b21fd173baebcfcb52490830b12292d8fe89b2147", size = 5344288, upload-time = "2026-05-23T17:39:18.965Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e5/a735751bd11558163e83e0961fc866e4f94634df9eb24937c5f59624e393/primp-1.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fabaac4280df0802377d34b869949d617a0ecf22ca7fd5f9bded3f5c981031f1", size = 5262909, upload-time = "2026-05-23T17:39:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8e/4e3d4520e2e751f2de825dbe2cb43f837d33a5528adc44255f9770ea125a/primp-1.3.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f510e5881e0a4c4b9e7dbc03722c316d58454388b88000a0e7bf18a4b36d601e", size = 4964809, upload-time = "2026-05-23T17:38:59.023Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/e7b7495687d07df693325a12c497a9e5185d5001b7b216f32019fa7437a0/primp-1.3.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0504de2901c97903a9c369856a4b186dc90a782d8320652c142b066e697d5a1a", size = 5083654, upload-time = "2026-05-23T17:39:06.598Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f9/e4652e93beb14a16cc4218cfb1ccc18eaca8ee7d93b517d614a135928ec9/primp-1.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c3b24e302d95d327e873834b9423823b9c8af2abf5e0bbf57a03f3354cfe528", size = 5594738, upload-time = "2026-05-23T17:39:27.001Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/49/e8c8a7bc6b741ab6f15896022eee4f906d04d7ccd15aeeb515dd04bbeb6d/primp-1.3.1-cp314-cp314t-win32.whl", hash = "sha256:4346dcef805279028bf4a54bb87dd43d0920130e25b5790689f5c96c9ba0d9e5", size = 4262615, upload-time = "2026-05-23T17:39:13.88Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/84/7ae4a257dec6dff329d4a8d9051d907316095c27ffc8d1ea15c359e6eeb5/primp-1.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:6c55f152a73b6d6af8ac37bdb648d8bbfd7e656f9ef40d87feb3c0d81cee930a", size = 4660584, upload-time = "2026-05-23T17:39:10.081Z" },
+    { url = "https://files.pythonhosted.org/packages/99/20/10e0d96bfaeef1f0cd339ccf9bb8feb4bf798fde93198f7a96c73441080a/primp-1.3.1-cp314-cp314t-win_arm64.whl", hash = "sha256:46a529d74583d6ceba52e15bf4c678fcf24e6d669c1ce935262d5490d1b25801", size = 4623226, upload-time = "2026-05-23T17:38:57.256Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 变更
- 补齐 Desktop CN 冻结 runtime 的 web dashboard、TUI、computer-use、Web provider 和模型快照打包契约。
- 将 `cn-desktop` extra 作为冻结 runtime 能力清单来源，预烘焙 computer-use、exa、firecrawl、parallel-web、ddgs。
- Web provider entrypoint 改为相对导入，并在 web tool check_fn 前触发插件发现。
- Desktop 模型菜单展示 provider fallback warning，后端 live discovery 失败时不把 bundled snapshot 当作真实可用模型数静默展示。

## 验证
- `uv run --extra dev --extra acp --extra cn-desktop python -m pytest tests/plugins/web/test_web_search_provider_plugins.py tests/tools/test_web_providers_searxng.py tests/tools/test_website_policy.py tests/test_runtime_release_workflow.py tests/hermes_cli/test_inventory.py tests/test_project_metadata.py -q`
- `uv run --extra dev --extra acp --extra cn-desktop ruff check .`
- `npm ci && npm --workspace web run build && test -f hermes_cli/web_dist/index.html && npm --workspace ui-tui run build && test -f ui-tui/dist/entry.js`
- `npm --workspace apps/desktop test -- model-menu-panel.test.tsx model-options.test.ts model-visibility.test.ts`
- `uv run --extra dev --extra acp --extra cn-desktop python -m pytest tests/hermes_cli/test_web_server.py -q`

## 备注
- 本地未实际构建 PyInstaller frozen artifact；workflow 内已补 frozen payload 和 smoke 断言。
- `scripts/run_tests.sh` 全量并行跑到 `43572 passed`，剩余失败/超时项单独复跑相关小项通过，`test_web_server.py` 单独通过。
