### PR TITLE
fix: 新增桌面首启配置文件生成

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8050,6 +8050,42 @@ def save_config(
         )
 
 
+def ensure_starter_config_file() -> Optional[Path]:
+    """Create a minimal first-run config.yaml if the user has none.
+
+    load_config() intentionally returns in-memory defaults when config.yaml is
+    absent. GUI/dashboard entrypoints still need a real file on first launch so
+    new desktop users have an obvious configuration surface and later writes do
+    not look like they appeared from nowhere. Keep this starter file small; do
+    not materialize DEFAULT_CONFIG here.
+    """
+    if is_managed():
+        return None
+
+    config_path = get_config_path()
+    if config_path.exists() or os.path.lexists(config_path):
+        return None
+    ensure_hermes_home()
+    if config_path.exists() or os.path.lexists(config_path):
+        return None
+
+    starter = {
+        "_config_version": DEFAULT_CONFIG.get("_config_version", 1),
+        "model": {
+            "provider": "",
+            "default": "",
+        },
+        "providers": {},
+    }
+    atomic_config_write(
+        config_path,
+        starter,
+        extra_content=_SECURITY_COMMENT + _FALLBACK_COMMENT,
+    )
+    _secure_file(config_path)
+    return config_path if config_path.exists() else None
+
+
 def _parse_env_value(raw_value: str) -> str:
     """Parse the small .env value subset Hermes writes itself."""
     value = raw_value.strip()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12724,6 +12724,16 @@ def cmd_dashboard(args):
     # backend is the desktop's primary entrypoint and needs the same.
     _sync_bundled_skills_quietly()
 
+    if not _headless_backend:
+        try:
+            from hermes_cli.config import ensure_starter_config_file
+
+            seeded_config = ensure_starter_config_file()
+            if seeded_config:
+                logger.info("Seeded starter config.yaml at %s", seeded_config)
+        except Exception:
+            logger.warning("Failed to seed starter config.yaml", exc_info=True)
+
     # Bridge terminal.* config into the TERMINAL_* env vars for THIS process,
     # mirroring the CLI (cli.py env_mappings) and gateway (gateway/run.py
     # _terminal_env_map) startup bridges. The dashboard/serve backend runs

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -74,6 +74,7 @@ from hermes_cli.config import (
     get_env_path,
     get_hermes_home,
     get_process_hermes_home,
+    ensure_starter_config_file,
     load_config,
     load_env,
     read_raw_config,
@@ -6201,6 +6202,7 @@ async def update_memory_provider_config(
 @app.get("/api/config")
 async def get_config(profile: Optional[str] = None):
     with _profile_scope(profile):
+        ensure_starter_config_file()
         config = _normalize_config_for_web(load_config())
     # Strip internal keys that the frontend shouldn't see or send back
     return {k: v for k, v in config.items() if not k.startswith("_")}

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -13,6 +13,7 @@ from hermes_cli.config import (
     check_config_version,
     get_hermes_home,
     ensure_hermes_home,
+    ensure_starter_config_file,
     get_compatible_custom_providers,
     _explicit_config_paths,
     _normalize_max_turns_config,
@@ -517,6 +518,43 @@ class TestSaveAndLoadRoundtrip:
         atomic_config_write(config_path, {"model": {"provider": "openrouter"}})
         assert config_path.exists()
         assert "openrouter" in config_path.read_text(encoding="utf-8", errors="replace")
+
+    def test_ensure_starter_config_file_creates_minimal_config(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            created = ensure_starter_config_file()
+
+        assert created == config_path
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8", errors="replace"))
+        assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+        assert raw["model"] == {"provider": "", "default": ""}
+        assert raw["providers"] == {}
+        assert "agent" not in raw
+        assert "terminal" not in raw
+
+    def test_ensure_starter_config_file_refreshes_no_file_cache(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            assert load_config()["_config_version"] == DEFAULT_CONFIG["_config_version"]
+            assert not config_path.exists()
+
+            ensure_starter_config_file()
+            reloaded = load_config()
+
+        assert config_path.exists()
+        assert reloaded["model"]["provider"] == ""
+        assert reloaded["model"]["default"] == ""
+
+    def test_ensure_starter_config_file_does_not_overwrite_existing_config(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        original = "model: existing/model\n"
+        config_path.write_text(original, encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            created = ensure_starter_config_file()
+
+        assert created is None
+        assert config_path.read_text(encoding="utf-8", errors="replace") == original
 
     def test_save_config_normalizes_legacy_root_level_max_turns(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4720,6 +4720,23 @@ class TestConfigRoundTrip:
         assert isinstance(config.get("model"), str), \
             f"model should be string, got {type(config.get('model'))}"
 
+    def test_get_config_seeds_missing_config_file(self):
+        """GET /api/config should create the first-run starter config.yaml."""
+        from hermes_constants import get_hermes_home
+
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.unlink(missing_ok=True)
+
+        resp = self.client.get("/api/config")
+
+        assert resp.status_code == 200
+        assert config_path.exists()
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8", errors="replace"))
+        assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+        assert raw["model"] == {"provider": "", "default": ""}
+        assert raw["providers"] == {}
+        assert "agent" not in raw
+
     def test_round_trip_preserves_model_subkeys(self):
         """Save and reload should not lose model.provider, model.base_url, etc."""
         from hermes_cli.config import load_config, save_config


### PR DESCRIPTION
## 背景
桌面端 managed runtime 使用独立 HERMES_HOME。新用户首次安装时没有现成的 config.yaml，但 dashboard/load_config 只返回内存默认配置，不会落盘，导致模型配置页和后续配置写入缺少明确的配置文件起点。

## 改动
- 新增 ensure_starter_config_file()，仅在 config.yaml 不存在时写入最小 starter 配置。
- dashboard 非 headless 启动时主动 seed。
- GET /api/config 读取前也做兜底 seed，覆盖直接打开配置页/API 的路径。
- starter 只包含 _config_version、空 model provider/default、providers: {}，避免把 DEFAULT_CONFIG 全量落盘。
- 增加配置模块和 /api/config 回归测试。

## 验证
- uv run --python 3.14 --extra dev python -m pytest tests/hermes_cli/test_config.py::TestSaveAndLoadRoundtrip::test_ensure_starter_config_file_creates_minimal_config tests/hermes_cli/test_config.py::TestSaveAndLoadRoundtrip::test_ensure_starter_config_file_refreshes_no_file_cache tests/hermes_cli/test_config.py::TestSaveAndLoadRoundtrip::test_ensure_starter_config_file_does_not_overwrite_existing_config tests/hermes_cli/test_web_server.py::TestConfigRoundTrip::test_get_config_seeds_missing_config_file -q
- uv run --python 3.14 --extra dev python -m pytest tests/hermes_cli/test_config.py::TestSaveAndLoadRoundtrip tests/hermes_cli/test_config.py::TestConfigNormalizationDoesNotOverwriteUserValues tests/hermes_cli/test_web_server.py::TestConfigRoundTrip -q
- uv run --python 3.14 --extra dev python -m pytest tests/hermes_cli/test_config.py -q
- uv run --python 3.14 --extra dev ruff check hermes_cli/config.py hermes_cli/main.py hermes_cli/web_server.py tests/hermes_cli/test_config.py tests/hermes_cli/test_web_server.py
- git diff --check
