### PR TITLE
fix: 合并 dev-fix 稳定性修复

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -324,6 +324,9 @@ jobs:
             --collect-submodules hindsight_client_api \
             --collect-submodules aiohttp_retry \
             --collect-submodules plugins.memory \
+            --hidden-import tools.lazy_deps \
+            --collect-submodules supermemory \
+            --collect-submodules mem0ai \
             --collect-data hermes_cli \
             --collect-data gateway \
             --collect-data plugins \
@@ -519,7 +522,7 @@ jobs:
                      aiohttp websockets apscheduler aiofiles qrcode pypng \
                      defusedxml cryptography pycryptodome certifi \
                      hindsight_client aiohttp_retry ddgs exa_py firecrawl_py \
-                     parallel_web; do
+                     parallel_web supermemory mem0ai; do
             if [[ -z "$(find "$internal" -maxdepth 1 -type d -name "${pkg}-*.dist-info" -print -quit)" ]]; then
               echo "::error::Frozen runtime is missing ${pkg} package metadata" >&2
               find "dist/$NAME" -maxdepth 3 -type d -iname "${pkg}*" -print >&2

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -186,7 +186,7 @@ def _codex_gpt55_autoraise_notice_seen(autoraise: Dict[str, Any]) -> bool:
             _codex_gpt55_autoraise_notice_marker().read_text(encoding="utf-8", errors="replace").strip()
             == current
         )
-    except OSError, KeyError, TypeError, ValueError:
+    except (OSError, KeyError, TypeError, ValueError):
         return False
 
 
@@ -202,7 +202,7 @@ def _record_codex_gpt55_autoraise_notice(autoraise: Dict[str, Any]) -> None:
         marker.write_text(
             _codex_gpt55_autoraise_notice_state(autoraise), encoding="utf-8"
         )
-    except OSError, KeyError, TypeError, ValueError:
+    except (OSError, KeyError, TypeError, ValueError):
         pass
 
 
@@ -1808,7 +1808,7 @@ def init_agent(
         _raw_api_retries = _agent_section.get("api_max_retries", 3)
         _api_retries = int(_raw_api_retries)
         _api_retries = max(_api_retries, 1)  # 1 = no retry (single attempt)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         _api_retries = 3
     agent._api_max_retries = _api_retries
 
@@ -1914,7 +1914,7 @@ def init_agent(
     if _aux_context_config is not None:
         try:
             _aux_context_config = int(_aux_context_config)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             _aux_context_config = None
     agent._aux_compression_context_length_config = _aux_context_config
 
@@ -1931,7 +1931,7 @@ def init_agent(
                 if _parsed_max_tokens <= 0:
                     raise ValueError
                 agent.max_tokens = _parsed_max_tokens
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 _ra().logger.warning(
                     "Invalid model.max_tokens in config.yaml: %r — "
                     "must be a positive integer (e.g. 4096). "
@@ -1954,7 +1954,7 @@ def init_agent(
     if _config_context_length is not None:
         try:
             _config_context_length = int(_config_context_length)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             _ra().logger.warning(
                 "Invalid model.context_length in config.yaml: %r — "
                 "must be a plain integer (e.g. 256000, not '256K'). "
@@ -2023,7 +2023,7 @@ def init_agent(
                                     _parsed = int(_cp_ctx)
                                     if _parsed <= 0:
                                         raise ValueError
-                                except TypeError, ValueError:
+                                except (TypeError, ValueError):
                                     _ra().logger.warning(
                                         "Invalid context_length for model %r in "
                                         "custom_providers: %r — must be a positive "
@@ -2205,7 +2205,7 @@ def init_agent(
     else:
         try:
             agent.steer_max_length = int(_steer_max_length)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             agent.steer_max_length = 4000
 
     # Unified reminder registry — system reminders + user steers share one
@@ -2376,7 +2376,7 @@ def init_agent(
     if _ollama_num_ctx_override is not None:
         try:
             agent._ollama_num_ctx = int(_ollama_num_ctx_override)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             _ra().logger.debug(
                 "Invalid ollama_num_ctx config value: %r", _ollama_num_ctx_override
             )

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -211,7 +211,7 @@ def convert_to_trajectory_format(
                     try:
                         if tool_content.strip().startswith(("{", "[")):
                             tool_content = orjson.loads(tool_content)
-                    except orjson.JSONDecodeError, AttributeError:
+                    except (orjson.JSONDecodeError, AttributeError):
                         pass  # Keep as string if not valid JSON
 
                     tool_index = len(tool_responses)
@@ -3506,7 +3506,7 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
         if retry_after not in {None, ""} and "reset_at" not in context:
             try:
                 context["reset_at"] = time.time() + float(retry_after)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 pass
 
     response = getattr(error, "response", None)
@@ -3516,7 +3516,7 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
         if retry_after and "reset_at" not in context:
             try:
                 context["reset_at"] = time.time() + float(retry_after)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 pass
         ratelimit_reset = headers.get("x-ratelimit-reset")
         if ratelimit_reset and "reset_at" not in context:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1724,7 +1724,7 @@ def run_conversation(
                         if _code_raw is not None:
                             try:
                                 _resp_error_code = int(_code_raw)
-                            except TypeError, ValueError:
+                            except (TypeError, ValueError):
                                 pass
 
                     # Build a human-readable failure hint from the error code
@@ -2520,7 +2520,7 @@ def run_conversation(
                     if _moa_ref_cost is not None:
                         try:
                             agent.session_estimated_cost_usd += float(_moa_ref_cost)
-                        except TypeError, ValueError:  # pragma: no cover - defensive
+                        except (TypeError, ValueError):  # pragma: no cover - defensive
                             pass
                     agent.session_cost_status = cost_result.status
                     agent.session_cost_source = cost_result.source
@@ -2554,7 +2554,7 @@ def run_conversation(
                                     _cost_delta = (_cost_delta or 0.0) + float(
                                         _moa_ref_cost
                                     )
-                                except TypeError, ValueError:  # pragma: no cover
+                                except (TypeError, ValueError):  # pragma: no cover
                                     pass
                             agent._session_db.update_token_counts(
                                 agent.session_id,
@@ -4818,7 +4818,7 @@ def run_conversation(
                                 # limit. 600s covers all realistic provider reset
                                 # windows while still rejecting pathological values. (#26293)
                                 _retry_after = min(float(_ra_raw), 600)
-                            except TypeError, ValueError:
+                            except (TypeError, ValueError):
                                 pass
                 if is_rate_limited and not _retry_after:
                     # 429 rate limit: short exponential backoff 1s → 2s → 4s → 4s (capped)
@@ -6352,7 +6352,7 @@ def run_conversation(
             )
             try:
                 print(f"❌ {error_msg}")
-            except OSError, ValueError:
+            except (OSError, ValueError):
                 logger.error(error_msg)
 
             # Emit the full traceback at ERROR level so it lands in both

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -911,7 +911,7 @@ def _chown_to_hermes_uid(path) -> None:
             uid if uid is not None else -1,
             gid if gid is not None else -1,
         )
-    except OSError, AttributeError, NotImplementedError:
+    except (OSError, AttributeError, NotImplementedError):
         # OSError covers EPERM (not running as root) and ENOENT (race),
         # both of which are non-fatal — the dir is still created and
         # the entrypoint's startup chown -R will fix it on next restart.
@@ -945,7 +945,7 @@ def _secure_dir(path):
         mode = 0o700
     try:
         os.chmod(path, mode)
-    except OSError, NotImplementedError:
+    except (OSError, NotImplementedError):
         pass
     _chown_to_hermes_uid(path)
 
@@ -974,7 +974,7 @@ def _is_container() -> bool:
             or "kubepods" in cgroup_content
         ):
             return True
-    except OSError, IOError:
+    except (OSError, IOError):
         pass
     return False
 
@@ -993,7 +993,7 @@ def _secure_file(path):
     try:
         if os.path.exists(str(path)):
             os.chmod(path, 0o600)
-    except OSError, NotImplementedError:
+    except (OSError, NotImplementedError):
         pass
 
 
@@ -1009,7 +1009,7 @@ def _ensure_default_soul_md(home: Path) -> None:
     if soul_path.exists():
         try:
             existing = soul_path.read_text(encoding="utf-8", errors="replace")
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             return
         if not is_legacy_template_soul(existing):
             return
@@ -4842,7 +4842,7 @@ def _set_nested(config, dotted_key: str, value):
         if isinstance(current, list):
             try:
                 idx = int(part)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 raise TypeError(
                     f"Cannot navigate into list at key {dotted_key!r}: "
                     f"segment {part!r} is not a numeric index"
@@ -5614,7 +5614,7 @@ def get_custom_provider_context_length(
             continue
         try:
             ctx = int(raw_ctx)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             continue
         if ctx > 0:
             return ctx
@@ -5627,7 +5627,7 @@ def _coerce_config_version(value: Any) -> int:
         return 0
     try:
         version = int(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return 0
     return max(version, 0)
 
@@ -6634,12 +6634,12 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             old_async = raw_deleg.pop("max_async_children")
             try:
                 old_async_i = int(old_async)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 old_async_i = None
             if old_async_i is not None and old_async_i > 3:
                 try:
                     cur_children = int(raw_deleg.get("max_concurrent_children", 3))
-                except TypeError, ValueError:
+                except (TypeError, ValueError):
                     cur_children = 3
                 if old_async_i > cur_children:
                     raw_deleg["max_concurrent_children"] = old_async_i
@@ -6770,7 +6770,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             print()
             try:
                 answer = input("  Configure new keys? [y/N]: ").strip().lower()
-            except EOFError, KeyboardInterrupt:
+            except (EOFError, KeyboardInterrupt):
                 answer = "n"
 
             if answer in {"y", "yes"}:
@@ -6828,7 +6828,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         print()
         try:
             answer = input("  Configure skill settings? [y/N]: ").strip().lower()
-        except EOFError, KeyboardInterrupt:
+        except (EOFError, KeyboardInterrupt):
             answer = "n"
 
         if answer in {"y", "yes"}:
@@ -7435,7 +7435,7 @@ def read_raw_config() -> Dict[str, Any]:
             config_path = get_config_path()
             st = config_path.stat()
             cache_key = (st.st_mtime_ns, st.st_size)
-        except FileNotFoundError, OSError:
+        except (FileNotFoundError, OSError):
             return {}
 
         path_key = str(config_path)

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -762,7 +762,24 @@ class HindsightMemoryProvider(MemoryProvider):
                 or os.environ.get("HINDSIGHT_API_KEY", "")
             )
             has_url = bool(cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", ""))
-            return has_key or has_url
+            has_config = has_key or has_url
+
+            if not has_config:
+                return False
+
+            # In a normal Python env with lazy_deps available, config-only check
+            # is correct because ensure() can install the SDK on demand later.
+            # But in the PyInstaller frozen runtime (CN Desktop), lazy_deps is
+            # not available and the SDK must be pre-baked — fall back to checking
+            # actual SDK importability to avoid a false green light. See P-040.
+            try:
+                from tools.lazy_deps import ensure as _lazy_ensure
+                return True
+            except ImportError:
+                # Frozen runtime: tools.lazy_deps is not bundled.
+                import importlib.util
+                return importlib.util.find_spec("hindsight") is not None \
+                       or importlib.util.find_spec("hindsight_client") is not None
         except Exception:
             return False
 

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -33,6 +33,7 @@ home for these non-secret settings.
 from __future__ import annotations
 
 import atexit
+import importlib.util
 import orjson
 import logging
 import os
@@ -227,10 +228,26 @@ class Mem0MemoryProvider(MemoryProvider):
         cfg = _load_config()
         mode = cfg.get("mode", "platform")
         if mode == "oss":
-            return bool(cfg.get("oss", {}).get("vector_store"))
-        # Platform needs an api_key; self-hosted needs a host (api_key optional
-        # when the server runs with AUTH_DISABLED).
-        return bool(cfg.get("api_key") or cfg.get("host"))
+            has_config = bool(cfg.get("oss", {}).get("vector_store"))
+        else:
+            # Platform needs an api_key; self-hosted needs a host (api_key optional
+            # when the server runs with AUTH_DISABLED).
+            has_config = bool(cfg.get("api_key") or cfg.get("host"))
+
+        if not has_config:
+            return False
+
+        # In a normal Python env with lazy_deps available, config-only check is
+        # correct because ensure() can install the SDK on demand later.
+        # But in the PyInstaller frozen runtime (CN Desktop), lazy_deps is not
+        # available and the SDK must be pre-baked — fall back to checking
+        # actual SDK importability to avoid a false green light.
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
+            return True
+        except ImportError:
+            # Frozen runtime: tools.lazy_deps is not bundled.
+            return importlib.util.find_spec("mem0") is not None
 
     def save_config(self, values, hermes_home):
         """Write config to $HERMES_HOME/mem0.json."""
@@ -517,7 +534,13 @@ class Mem0MemoryProvider(MemoryProvider):
         if self._backend is None:
             err = getattr(self, "_init_error", "unknown error")
             hint = ""
-            if self._mode == "oss":
+            if "No module" in err or "ModuleNotFoundError" in err:
+                hint = (
+                    " The mem0 SDK is not available in this runtime. "
+                    "It must be bundled in the desktop installer; "
+                    "installed Python packages are not visible to the frozen runtime."
+                )
+            elif self._mode == "oss":
                 vs = self._config.get("oss", {}).get("vector_store", {})
                 provider = vs.get("provider", "vector store")
                 hint = f" Check that {provider} is running and reachable."

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -6,6 +6,7 @@ explicit memory tools, cleaned turn capture, and session-end conversation ingest
 
 from __future__ import annotations
 
+import importlib.util
 import orjson
 import logging
 import os
@@ -553,6 +554,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._hermes_home = ""
         self._write_enabled = True
         self._active = False
+        self._init_error: Optional[str] = None
         # Multi-container support
         self._enable_custom_containers = False
         self._custom_containers: List[str] = []
@@ -572,7 +574,27 @@ class SupermemoryMemoryProvider(MemoryProvider):
         # Docker venv the package isn't present until ensure() runs, but
         # ensure() only runs once the provider is loaded — which this gates.
         # Mirrors honcho/mem0, which check config only. No network calls.
-        return bool(os.environ.get("SUPERMEMORY_API_KEY", ""))
+        #
+        # HOWEVER: in the PyInstaller frozen runtime (CN Desktop), lazy_deps
+        # is NOT available (no pip inside frozen binary) AND the SDK must be
+        # pre-baked. When tools.lazy_deps cannot be imported, fall back to
+        # importlib.util.find_spec so is_available() reports the actual
+        # importability of the SDK rather than producing a false green light.
+        if not os.environ.get("SUPERMEMORY_API_KEY", ""):
+            return False
+        # Check if we can potentially load the SDK. In a normal Python env
+        # with lazy_deps available, just having the key is sufficient. In the
+        # frozen runtime, we need the SDK to actually be importable.
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
+            # lazy_deps is available — the key-only check is correct because
+            # ensure() can install the SDK on demand later.
+            return True
+        except ImportError:
+            # Frozen runtime: tools.lazy_deps is not bundled. Fall back to
+            # checking whether the SDK is actually importable. This prevents
+            # the false green light reported in P-040.
+            return importlib.util.find_spec("supermemory") is not None
 
     def get_config_schema(self):
         # Only prompt for the API key during `hermes memory setup`.
@@ -676,6 +698,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
 
         agent_context = kwargs.get("agent_context", "")
         self._write_enabled = agent_context not in {"cron", "flush", "subagent"}
+        self._init_error = None
         self._active = bool(self._api_key)
         self._client = None
         if self._active:
@@ -687,8 +710,9 @@ class SupermemoryMemoryProvider(MemoryProvider):
                     search_mode=self._search_mode,
                     base_url=self._base_url,
                 )
-            except Exception:
+            except Exception as exc:
                 logger.warning("Supermemory initialization failed", exc_info=True)
+                self._init_error = str(exc)
                 self._active = False
                 self._client = None
 
@@ -1021,6 +1045,14 @@ class SupermemoryMemoryProvider(MemoryProvider):
 
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
         if not self._active or not self._client:
+            if self._init_error and ("ModuleNotFoundError" in self._init_error
+                                      or "No module" in self._init_error):
+                return tool_error(
+                    f"Supermemory SDK not available in this runtime "
+                    f"({self._init_error}). The SDK must be bundled in the "
+                    f"desktop installer; installed Python packages are not "
+                    f"visible to the frozen runtime."
+                )
             return tool_error("Supermemory is not configured")
         aliases = {
             "supermemory-save": "supermemory_store",

--- a/run_agent.py
+++ b/run_agent.py
@@ -940,7 +940,7 @@ class AIAgent:
         try:
             fn = self._print_fn or print
             fn(*args, **kwargs)
-        except OSError, ValueError:
+        except (OSError, ValueError):
             pass
 
     def _vprint(self, *args, force: bool = False, **kwargs):
@@ -986,7 +986,7 @@ class AIAgent:
             return False
         try:
             return bool(stream.isatty())
-        except AttributeError, ValueError, OSError:
+        except (AttributeError, ValueError, OSError):
             return False
 
     def _should_emit_quiet_tool_messages(self) -> bool:
@@ -1621,7 +1621,7 @@ class AIAgent:
             raw = api_kwargs.get(key)
             try:
                 value = int(raw)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 continue
             if value > 0:
                 return value
@@ -2486,7 +2486,7 @@ class AIAgent:
                 prefix = f"HTTP {status_code}: " if status_code else ""
                 try:
                     payload = orjson.loads(snippet)
-                except orjson.JSONDecodeError, TypeError:
+                except (orjson.JSONDecodeError, TypeError):
                     payload = None
                 if isinstance(payload, dict):
                     err = payload.get("error")
@@ -2572,7 +2572,7 @@ class AIAgent:
         raw = os.getenv("HERMES_PLUGIN_PAYLOAD_MAX_CHARS", "50000")
         try:
             return max(1000, int(raw))
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return 50000
 
     @staticmethod
@@ -3972,7 +3972,7 @@ class AIAgent:
                 if "todos" in data and isinstance(data["todos"], list):
                     last_todo_response = data["todos"]
                     break
-            except orjson.JSONDecodeError, TypeError:
+            except (orjson.JSONDecodeError, TypeError):
                 continue
 
         if last_todo_response:

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -328,7 +328,7 @@ async def test_non_admin_denied_for_unlisted_quick_command_exec():
         }
     )
     runner.config.quick_commands = {
-        "limits": {"type": "exec", "command": "printf quick-command-bypass-confirmed"}
+        "limits": {"type": "exec", "command": "echo quick-command-bypass-confirmed"}
     }
 
     result = await runner._handle_message(
@@ -352,7 +352,7 @@ async def test_listed_quick_command_runs_for_non_admin():
         }
     )
     runner.config.quick_commands = {
-        "limits": {"type": "exec", "command": "printf quick-command-allowed"}
+        "limits": {"type": "exec", "command": "echo quick-command-allowed"}
     }
 
     result = await runner._handle_message(
@@ -373,7 +373,7 @@ async def test_admin_runs_quick_command_when_gating_enabled():
         }
     )
     runner.config.quick_commands = {
-        "limits": {"type": "exec", "command": "printf quick-command-admin"}
+        "limits": {"type": "exec", "command": "echo quick-command-admin"}
     }
 
     result = await runner._handle_message(

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -720,11 +720,14 @@ class TestSaveEnvValueSecure:
             assert load_env()["TERMINAL_SSH_KEY"] == path
 
             # Shell source must round-trip (this is what the bug broke).
-            # POSIX-only: there is no `sh` on Windows; dotenv round-trip above
-            # already covers the quoting contract there.
+            # POSIX-only: there is no usable `sh` on Windows — Git's sh is
+            # found by shutil.which() but `env -i` clears PATH, so the
+            # sub-check cannot run there; the dotenv round-trip above already
+            # covers the quoting contract.
             import shutil
+            import sys
 
-            if not shutil.which("sh"):
+            if sys.platform == "win32" or not shutil.which("sh"):
                 return
             r = subprocess.run(
                 [
@@ -762,8 +765,9 @@ class TestSaveEnvValueSecure:
 
             # POSIX-only shell-source check (see above).
             import shutil
+            import sys
 
-            if not shutil.which("sh"):
+            if sys.platform == "win32" or not shutil.which("sh"):
                 return
             r = subprocess.run(
                 [

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -190,13 +190,17 @@ def detect_audio_environment() -> dict:
                 "    PipeWire:    -e PIPEWIRE_REMOTE=$XDG_RUNTIME_DIR/pipewire-0"
             )
 
-    # WSL detection — PulseAudio bridge makes audio work in WSL.
-    # Only block if PULSE_SERVER is not configured.
+	# WSL detection — PulseAudio/PipeWire bridge makes audio work in WSL.
+    # Only block if no host audio forwarding is configured (PULSE_SERVER /
+    # PIPEWIRE_REMOTE / reachable pulse socket), matching the SSH and
+    # container branches above. WSLg exposes both a PulseAudio and a
+    # PipeWire socket, so honoring PIPEWIRE_REMOTE alone is enough to
+    # unblock voice mode on modern WSL setups (issue #21203 pattern).
     try:
         with open('/proc/version', 'r', encoding="utf-8", errors="replace") as f:
             if 'microsoft' in f.read().lower():
-                if os.environ.get('PULSE_SERVER'):
-                    notices.append("Running in WSL with PulseAudio bridge")
+                if has_forwarded_audio:
+                    notices.append("Running in WSL with host audio forwarding")
                 else:
                     warnings.append(
                         "Running in WSL -- audio requires PulseAudio bridge.\n"


### PR DESCRIPTION
## 变更

- 修复 Python 3.14 下多异常捕获的语法错误。
- 完善冻结运行时中 Hindsight、Supermemory 与 Mem0 的可用性判断和 SDK 收集。
- 兼容 Windows 测试环境，并让 WSL 音频检测复用宿主音频转发判断。
- 已将 `dev-fix` rebase 到最新 `origin/main`；运行时工作流冲突按能力并集合并，保留 `plugins.memory`、Web 搜索后端及新增内存 SDK。

## 原因

`dev-fix` 中的修复基于旧主线，直接合并会与当前冻结运行时发布配置冲突，并保留若干 Python 3.14 语法与跨平台兼容问题。

## 影响

修复后，Core 可在当前 Python 3.14 主线上正常解析相关模块，冻结桌面运行时能够显式收集内存提供方依赖，Windows/WSL 路径也更稳定。

## 验证

- 变更 Python 文件 Ruff 检查通过。
- Python 3.14 语法编译通过。
- `scripts/run_tests.sh` 定向运行 7 个相关测试文件：505 passed。
- `git diff --check` 通过。