### PR TITLE
ci: 修复 runtime release 飞书验证

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -213,6 +213,7 @@ jobs:
           import plugins.platforms.wecom.adapter as wcm
           import plugins.platforms.wecom.callback_adapter as wc
           import gateway.platforms.weixin as wx
+          feishu_available = fs._load_lark_oapi()
           for m in (
               "tools.computer_use_tool",
               "tools.computer_use.tool",
@@ -232,7 +233,7 @@ jobs:
               except Exception as e:
                   missing.append(f"{m}: {type(e).__name__}: {e}")
           flags = {
-              "feishu.FEISHU_AVAILABLE": fs.FEISHU_AVAILABLE,
+              "feishu.FEISHU_AVAILABLE": feishu_available and fs.FEISHU_AVAILABLE,
               "dingtalk.DINGTALK_STREAM_AVAILABLE": dt.DINGTALK_STREAM_AVAILABLE,
               "dingtalk.CARD_SDK_AVAILABLE": dt.CARD_SDK_AVAILABLE,
               "wecom.AIOHTTP_AVAILABLE": wcm.AIOHTTP_AVAILABLE,


### PR DESCRIPTION
## 变更
- 在 runtime release 的 build-env 验证中显式调用 Feishu adapter 的 lazy SDK loader。
- 保留原有 `FEISHU_AVAILABLE` flag 断言，确保 `lark-oapi` 真正可导入后才放行。

## 原因
`plugins.platforms.feishu.adapter` 当前默认延迟加载 `lark_oapi`，直接 import adapter 后读取 `FEISHU_AVAILABLE` 会保持 false，导致 `runtime-v0.20.0-cn.1` release workflow 在 Linux、Windows、macOS arm64 上失败。

## 验证
- 本地调用 `fs._load_lark_oapi()` 后 `feishu.FEISHU_AVAILABLE` 为 true。
- `git diff --check`
