### PR TITLE
feat: 网关事件带上稳定的回合 id（turn_id）

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -502,7 +502,7 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
 
     def run_flag_off():
         events = []
-        monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: events.append((event, sid, payload)))
+        monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None, **_kw: events.append((event, sid, payload)))
         monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": False}})
         server._sessions["sid"] = _session(
             agent=_Agent(), model_override={"model": "gold-model", "provider": "gold-provider"}
@@ -518,7 +518,7 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
 
     def run_flag_on():
         events = []
-        monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: events.append((event, sid, payload)))
+        monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None, **_kw: events.append((event, sid, payload)))
         monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
 
         class _FakeSupervisor:
@@ -9016,7 +9016,7 @@ def test_prompt_submit_history_version_mismatch_surfaces_warning(monkeypatch):
         monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
         monkeypatch.setattr(server, "_get_usage", lambda _a: {})
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
-        monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
+        monkeypatch.setattr(server, "_emit", lambda *a, **_kw: emits.append(a))
 
         resp = server.handle_request(
             {
@@ -9121,7 +9121,7 @@ def test_prompt_submit_merges_on_model_switch_marker(monkeypatch):
             monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
             monkeypatch.setattr(server, "_get_usage", lambda _a: {})
             monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
-            monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
+            monkeypatch.setattr(server, "_emit", lambda *a, **_kw: emits.append(a))
 
             resp = server.handle_request(
                 {
@@ -9229,7 +9229,7 @@ def test_prompt_submit_history_version_match_persists_normally(monkeypatch):
         monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
         monkeypatch.setattr(server, "_get_usage", lambda _a: {})
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
-        monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
+        monkeypatch.setattr(server, "_emit", lambda *a, **_kw: emits.append(a))
 
         resp = server.handle_request(
             {
@@ -9292,7 +9292,7 @@ def test_prompt_submit_snapshots_history_after_pending_model_switch(monkeypatch)
         monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda *_a: None)
         monkeypatch.setattr(server, "_get_usage", lambda _a: {})
         monkeypatch.setattr(server, "render_message", lambda *_a: "")
-        monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
+        monkeypatch.setattr(server, "_emit", lambda *a, **_kw: emits.append(a))
 
         server.handle_request(
             {"id": "1", "method": "prompt.submit", "params": {"session_id": "sid", "text": "hi"}}
@@ -12205,7 +12205,7 @@ def test_prompt_submit_surfaces_backend_error_as_visible_text(monkeypatch):
     monkeypatch.setattr(
         server,
         "_emit",
-        lambda event, sid, payload=None: emitted.append((event, sid, payload or {})),
+        lambda event, sid, payload=None, **_kw: emitted.append((event, sid, payload or {})),
     )
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
@@ -12248,7 +12248,7 @@ def test_prompt_submit_preserves_empty_response_without_error(monkeypatch):
     monkeypatch.setattr(
         server,
         "_emit",
-        lambda event, sid, payload=None: emitted.append((event, sid, payload or {})),
+        lambda event, sid, payload=None, **_kw: emitted.append((event, sid, payload or {})),
     )
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
@@ -12417,7 +12417,7 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
     monkeypatch.setattr(server, "_get_db", lambda: None)
     monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
 
-    def _emit(event, sid, payload=None):
+    def _emit(event, sid, payload=None, **_kw):
         if event == "message.complete":
             done.set()
 

--- a/tests/test_tui_gateway_turn_id.py
+++ b/tests/test_tui_gateway_turn_id.py
@@ -1,0 +1,144 @@
+"""Gateway events carry a stable per-turn id (``turn_id``).
+
+Before this, events carried only ``type`` + ``session_id``, so a client had no
+way to distinguish "same turn, more output" from "a new turn started" and had to
+infer turn identity from stream state plus text/tool-call heuristics. A
+duplicated ``message.start`` (several dispatch paths pre-emit one before
+``_run_prompt_submit`` emits its own) or a reconnect replay then looked exactly
+like a fresh turn and split one reply into two bubbles.
+
+The id is in-memory only (it lives on ``inflight_turn``), so nothing here
+touches persistence or schema.
+"""
+
+import pytest
+
+from tui_gateway import server
+
+
+@pytest.fixture
+def session(monkeypatch):
+    """Register a bare session in the module registry, cleaned up after."""
+    sid = "sess-turn-id"
+    sess: dict = {"inflight_turn": None}
+    monkeypatch.setitem(server._sessions, sid, sess)
+    return sid, sess
+
+
+def test_turn_id_absent_while_session_idle(session):
+    """An idle session emits byte-identical frames to the pre-change shape."""
+    sid, _ = session
+    frame = server._event_frame("status.update", sid, {"text": "x"})
+
+    assert "turn_id" not in frame["params"]
+    assert frame == {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {"type": "status.update", "session_id": sid, "payload": {"text": "x"}},
+    }
+
+
+def test_turn_id_absent_for_sessionless_global_broadcast():
+    """``skin.changed``-style global events have no session, so no turn."""
+    frame = server._event_frame("skin.changed", "")
+
+    assert "turn_id" not in frame["params"]
+
+
+def test_turn_id_absent_for_unknown_session():
+    frame = server._event_frame("message.start", "no-such-session")
+
+    assert "turn_id" not in frame["params"]
+
+
+def test_every_event_of_a_turn_shares_one_turn_id(session):
+    """The whole turn — start, deltas, tool events — is stamped identically."""
+    sid, sess = session
+    server._start_inflight_turn(sess, "hello")
+
+    ids = {
+        server._event_frame(kind, sid)["params"].get("turn_id")
+        for kind in ("message.start", "message.delta", "tool.start", "reasoning.delta")
+    }
+
+    assert len(ids) == 1
+    turn_id = ids.pop()
+    assert isinstance(turn_id, str) and turn_id.startswith("turn_")
+
+
+def test_new_turn_gets_a_different_id(session):
+    """Consecutive turns are distinguishable — the whole point of the field."""
+    sid, sess = session
+
+    server._start_inflight_turn(sess, "first")
+    first = server._event_frame("message.start", sid)["params"]["turn_id"]
+
+    server._start_inflight_turn(sess, "second")
+    second = server._event_frame("message.start", sid)["params"]["turn_id"]
+
+    assert first != second
+
+
+def test_duplicate_message_start_is_idempotent_within_one_turn(session):
+    """Five dispatch paths pre-emit ``message.start`` before
+    ``_run_prompt_submit`` emits its own (server.py documents the double-fire at
+    the steer path). Both frames must report the SAME turn, so a client keyed on
+    turn_id cannot be tricked into opening a second bubble."""
+    sid, sess = session
+    server._start_inflight_turn(sess, "hello")
+
+    pre_emit = server._event_frame("message.start", sid)["params"]["turn_id"]
+    # _run_prompt_submit reuses a live turn rather than replacing it, so the
+    # second start lands inside the same turn.
+    from_submit = server._event_frame("message.start", sid)["params"]["turn_id"]
+
+    assert pre_emit == from_submit
+
+
+def test_terminal_frame_keeps_turn_id_after_the_turn_is_cleared(session):
+    """``_clear_inflight_turn`` runs under history_lock BEFORE
+    ``message.complete`` is emitted, so the closing frame — the one a client most
+    needs to attribute — would otherwise arrive unstamped. The explicit override
+    carries it across the clear."""
+    sid, sess = session
+    server._start_inflight_turn(sess, "hello")
+    completed_turn_id = server._current_turn_id(sid)
+
+    server._clear_inflight_turn(sess)
+
+    # Without the override the frame is unstamped …
+    assert "turn_id" not in server._event_frame("message.complete", sid)["params"]
+    # … with it, the terminal frame still names its turn.
+    stamped = server._event_frame(
+        "message.complete", sid, {"text": "done"}, turn_id=completed_turn_id
+    )
+    assert stamped["params"]["turn_id"] == completed_turn_id
+
+
+def test_failed_turn_retains_its_turn_id_for_resume_replay(session):
+    """``_fail_inflight_turn`` keeps the snapshot replayable; the id must
+    survive so a resuming client can attribute the retained failure."""
+    sid, sess = session
+    server._start_inflight_turn(sess, "hello")
+    before = server._current_turn_id(sid)
+
+    sess["history_lock"] = __import__("threading").RLock()
+    with sess["history_lock"]:
+        server._fail_inflight_turn(sess, "provider exploded")
+
+    assert server._current_turn_id(sid) == before
+
+
+def test_malformed_inflight_turn_does_not_raise(session):
+    """Defensive: a non-dict / id-less snapshot yields no turn_id rather than
+    breaking every event on the session."""
+    sid, sess = session
+
+    sess["inflight_turn"] = "not-a-dict"
+    assert server._current_turn_id(sid) is None
+
+    sess["inflight_turn"] = {"assistant": ""}  # no turn_id key
+    assert server._current_turn_id(sid) is None
+
+    sess["inflight_turn"] = {"turn_id": ""}  # empty string is not an id
+    assert server._current_turn_id(sid) is None

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -73,7 +73,7 @@ def emits(monkeypatch):
     monkeypatch.setattr(
         server,
         "_emit",
-        lambda event, sid, payload=None: captured.append((event, sid, payload)),
+        lambda event, sid, payload=None, **_kw: captured.append((event, sid, payload)),
     )
     return captured
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1592,15 +1592,40 @@ def write_json(obj: dict) -> bool:
     return (current_transport() or _stdio_transport).write(obj)
 
 
-def _event_frame(event: str, sid: str, payload: dict | None = None) -> dict:
+def _event_frame(
+    event: str,
+    sid: str,
+    payload: dict | None = None,
+    *,
+    turn_id: str | None = None,
+) -> dict:
     params: dict = {"type": event, "session_id": sid}
+    # Stamp the in-flight turn id on every event of a turn, from one place, so
+    # a client can group by turn instead of guessing from stream state (see
+    # _new_turn_id). Purely additive: idle sessions and session-less global
+    # broadcasts emit no turn_id, and clients that don't know the field ignore
+    # it (every event schema is passthrough), so old↔new mixes are unaffected.
+    #
+    # ``turn_id`` is an explicit override for terminal frames: the turn's
+    # snapshot is cleared under history_lock BEFORE message.complete is emitted,
+    # so by then _current_turn_id would return None and the closing frame — the
+    # one a client most needs to attribute — would arrive unstamped.
+    stamped = turn_id or _current_turn_id(sid)
+    if stamped:
+        params["turn_id"] = stamped
     if payload is not None:
         params["payload"] = payload
     return {"jsonrpc": "2.0", "method": "event", "params": params}
 
 
-def _emit(event: str, sid: str, payload: dict | None = None):
-    write_json(_event_frame(event, sid, payload))
+def _emit(
+    event: str,
+    sid: str,
+    payload: dict | None = None,
+    *,
+    turn_id: str | None = None,
+):
+    write_json(_event_frame(event, sid, payload, turn_id=turn_id))
 
 
 # Live client transports, one per connected WS peer (maintained by tui_gateway.ws).
@@ -7261,6 +7286,38 @@ def _inflight_text(value: Any) -> str:
     return _content_display_text(value).strip()
 
 
+def _new_turn_id() -> str:
+    """Mint a stable id for one agent turn.
+
+    Clients previously had NO way to tell "same turn, more output" from "a new
+    turn started": gateway events carried only ``type`` + ``session_id``, so a
+    UI had to infer turn identity from stream state and text/tool-call
+    heuristics. A duplicated ``message.start`` (several dispatch paths pre-emit
+    one before ``_run_prompt_submit`` emits its own) or a reconnect replay then
+    looked exactly like a fresh turn and split one reply into two bubbles.
+
+    The id is per-turn and in-memory only — it lives on ``inflight_turn`` and
+    dies with it, so nothing is persisted and no schema migration is involved.
+    """
+    return f"turn_{uuid.uuid4().hex[:16]}"
+
+
+def _current_turn_id(sid: str) -> str | None:
+    """Return the in-flight turn id for ``sid``, or ``None`` when idle.
+
+    Read by ``_event_frame`` so every event of a turn is stamped from one
+    place; a session with no live turn simply yields no ``turn_id`` and the
+    frame stays byte-identical to what older clients already handle.
+    """
+    if not sid:
+        return None
+    turn = (_sessions.get(sid) or {}).get("inflight_turn")
+    if not isinstance(turn, dict):
+        return None
+    turn_id = turn.get("turn_id")
+    return turn_id if isinstance(turn_id, str) and turn_id else None
+
+
 def _start_inflight_turn(session: dict, text: Any) -> None:
     now = time.time()
     session["inflight_turn"] = {
@@ -7268,6 +7325,7 @@ def _start_inflight_turn(session: dict, text: Any) -> None:
         "started_at": now,
         "streaming": True,
         "updated_at": now,
+        "turn_id": _new_turn_id(),
         "user": _inflight_text(text),
     }
 
@@ -10143,6 +10201,11 @@ def _run_prompt_submit(
             rendered = render_message(raw, cols)
             if rendered:
                 payload["rendered"] = rendered
+            # Read the turn id BEFORE the clear below drops the snapshot, then
+            # stamp it explicitly on the terminal frame — otherwise the closing
+            # event arrives with no turn_id and a client cannot tell which turn
+            # it finalizes.
+            completed_turn_id = _current_turn_id(sid)
             with session["history_lock"]:
                 if status == "error":
                     # Returned-error result (provider 4xx, budget, etc.): retain
@@ -10162,7 +10225,7 @@ def _run_prompt_submit(
                 )
                 payload["recoverable"] = True
             _retire_turn_marker(session, marker_key)
-            _emit("message.complete", sid, payload)
+            _emit("message.complete", sid, payload, turn_id=completed_turn_id)
 
             # ── /goal continuation (Ralph-style loop) ─────────────────
             # After every TUI turn, if a /goal is active, ask the judge


### PR DESCRIPTION
## 背景

网关事件此前只带 `type` + `session_id`,客户端无从区分「同一回合的后续输出」和「新回合开始」,只能靠流式状态加文本/工具调用的启发式,去反推一件后端本来就知道的事。

后果:重复的 `message.start`(有 5 处调用点在 `_run_prompt_submit` 之前预先 emit 一次,而它自己也会 emit——`server.py:10421` 的注释早就记下了这个坑)或重连重放,看起来跟新回合一模一样,一条回复被拆成两个气泡。

## 改动

`_start_inflight_turn` 生成 `turn_id`,由 `_event_frame` 统一给一个回合的每个事件盖章。客户端可以直接按回合分组:

```
turn_id 相同 → 同一回合
turn_id 不同 → 新回合
turn_id 缺失 → 未知(旧客户端/空闲会话)
```

## 升级安全

**纯增量、不落库。** id 只活在 `inflight_turn` 快照里,随回合结束消失:

- 不动 schema、不需要 migration、无 schema 重置风险
- 降级回旧版本不留任何残留
- 空闲会话与无会话的全局广播不带这个字段,帧形态与改动前**逐字节一致**
- 不认识该字段的客户端直接忽略(事件 schema 都是 `passthrough`)

新旧混搭任意组合都安全,**不要求客户端先行**:

| 桌面端 | Core | 结果 |
|---|---|---|
| 旧 | 新 | 字段被忽略,行为同现在 |
| 新 | 旧 | 无 `turn_id` → 退回原有启发式 |
| 新 | 新 | 走 id 比较,双 `message.start` 幂等 |

## 两处顺序陷阱(随测试固定)

实现过程中发现两个会让「加了 id 反而更糟」的时序问题:

1. **终态帧**:`_clear_inflight_turn` 在 `message.complete` **之前**就把快照清了(`server.py:10199` vs `10206`),此时 `_current_turn_id` 已返回 `None`——最需要归属的收尾帧反而没有 id。因此加了显式 `turn_id` 覆盖参数,在清理前读出、盖到终态帧上。

2. **失败回合**:`_fail_inflight_turn` 原地改写同一个 dict,`turn_id` 得以保留,`session.resume` 重放时仍能归属。

## 验证

- 新增 `tests/test_tui_gateway_turn_id.py`,**9 个测试**覆盖:空闲无 id、无会话广播、一个回合内所有事件同 id、新回合换 id、重复 `message.start` 幂等、终态帧跨清理保留 id、失败回合保留 id、畸形快照不抛异常
- **所有打桩 `_emit` 的测试套件全过:926 passed, 1 skipped**(含 `test_tui_gateway_server.py`、`tests/tui_gateway/` 全目录、`test_lazy_session_regressions.py` 等)
- 端到端确认真实帧:一个回合的 start/delta/complete 共享同一 id,空闲时不带

测试侧把若干 `_emit` 打桩的签名放宽以接受新关键字参数(纯测试改动,不涉及产品行为)。

## 配套

Desktop 侧消费见 Hermes-CN-Desktop 的 `feat/gateway-turn-id`。两边可独立发布,不需要按顺序上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)