### PR TITLE
fix: 修复覆盖升级后自定义模型配置失效

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6111,18 +6111,25 @@ def resolve_provider_client(
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
                 custom_key = _scoped_key_env(custom_key_env)
-            custom_key = custom_key or "no-key-required"
-            if custom_key == "no-key-required":
-                logger.warning(
-                    "resolve_provider_client: named custom provider %r has no resolvable "
-                    "api_key — request will be sent with placeholder no-key-required "
-                    "and will 401 on auth-required endpoints",
-                    custom_entry.get("name") or provider,
-                )
             # An explicit per-task api_mode override (from _resolve_task_provider_model)
             # wins; otherwise fall back to what the provider entry declared.
             entry_api_mode = (api_mode or custom_entry.get("api_mode") or "").strip()
             if custom_base:
+                if not custom_key:
+                    custom_key = _read_main_api_key_if_same_host(custom_base)
+                if (
+                    not custom_key
+                    and entry_api_mode == "anthropic_messages"
+                    and not base_url_host_matches(custom_base, "localhost")
+                    and base_url_hostname(custom_base) not in {"127.0.0.1", "::1", "0.0.0.0"}
+                ):
+                    logger.warning(
+                        "resolve_provider_client: named custom provider %r has no "
+                        "resolvable api_key/key_env for anthropic_messages",
+                        custom_entry.get("name") or provider,
+                    )
+                    return None, None
+                custom_key = custom_key or "no-key-required"
                 final_model = _normalize_resolved_model(
                     model
                     or custom_entry.get("model")

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3151,7 +3151,7 @@ DEFAULT_CONFIG = {
         "subagent_type": "coder",
     },
     # Config schema version - bump this when adding new required fields
-    "_config_version": 33,
+    "_config_version": 34,
 }
 
 # Optional environment variables that enhance functionality

--- a/hermes_cli/config_migrations.py
+++ b/hermes_cli/config_migrations.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 
 
 import copy
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 #: Auto-migration support floor. Configs whose on-disk ``_config_version`` is
 #: below this are NOT auto-migrated any more (policy decision, July 2026):
@@ -667,6 +667,310 @@ def _migrate_to_33(results: Dict[str, Any], quiet: bool) -> None:
             )
 
 
+def _provider_key_from_inline_model_provider(raw_provider: str, base_url: str) -> str:
+    provider = str(raw_provider or "").strip().lower()
+    if provider.startswith("custom:"):
+        provider = provider.split(":", 1)[1].strip()
+    key = "".join(ch if ch.isalnum() else "-" for ch in provider)
+    while "--" in key:
+        key = key.replace("--", "-")
+    key = key.strip("-")
+    if key:
+        return key
+    try:
+        from urllib.parse import urlparse
+
+        host = (urlparse(base_url).hostname or "endpoint").lower()
+        key = "".join(ch if ch.isalnum() else "-" for ch in host)
+        while "--" in key:
+            key = key.replace("--", "-")
+        return key.strip("-") or "endpoint"
+    except Exception:
+        return "endpoint"
+
+
+def _inline_model_provider_aliases(value: str) -> set[str]:
+    from hermes_cli.providers import custom_provider_aliases
+
+    raw = str(value or "").strip().lower()
+    if not raw:
+        return set()
+    aliases = set(custom_provider_aliases(raw, raw))
+    if raw.startswith("custom:"):
+        suffix = raw.split(":", 1)[1].strip()
+        if suffix:
+            aliases.add(suffix)
+            aliases.add(f"custom:{suffix}")
+    else:
+        aliases.add(f"custom:{raw}")
+    return {alias.strip().lower() for alias in aliases if alias}
+
+
+def _inline_model_provider_should_recover(provider_value: str) -> bool:
+    provider_norm = str(provider_value or "").strip().lower()
+    if not provider_norm or provider_norm in {"auto", "custom", "openrouter", "moa"}:
+        return False
+    if provider_norm.startswith("custom:"):
+        return bool(provider_norm.split(":", 1)[1].strip())
+    try:
+        from hermes_cli import auth as auth_mod
+
+        if auth_mod.is_runtime_provider_routable(provider_norm):
+            return False
+    except Exception:
+        pass
+    return True
+
+
+def _inline_model_base_url(model_cfg: Dict[str, Any]) -> str:
+    for key in ("base_url", "url", "api"):
+        raw = model_cfg.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip().rstrip("/")
+    return ""
+
+
+def _has_usable_secret(value: Any) -> bool:
+    try:
+        from hermes_cli.auth import has_usable_secret
+
+        return has_usable_secret(value)
+    except Exception:
+        return isinstance(value, str) and bool(value.strip())
+
+
+def _provider_entry_has_secret(entry: Dict[str, Any]) -> bool:
+    api_key = entry.get("api_key")
+    if _has_usable_secret(api_key):
+        return True
+    key_env = entry.get("key_env") or entry.get("api_key_env")
+    return isinstance(key_env, str) and bool(key_env.strip())
+
+
+def _provider_env_name(value: str) -> str:
+    raw = str(value or "").strip().lower()
+    if raw.startswith("custom:"):
+        raw = raw.split(":", 1)[1].strip()
+    chars = [ch.upper() if ch.isalnum() else "_" for ch in raw]
+    name = "".join(chars).strip("_")
+    while "__" in name:
+        name = name.replace("__", "_")
+    if not name or not name[0].isalpha():
+        return ""
+    return f"{name}_API_KEY"
+
+
+def _inline_provider_env_candidates(raw_provider: str, provider_key: str) -> List[str]:
+    names: List[str] = []
+    for value in (raw_provider, provider_key):
+        env_name = _provider_env_name(value)
+        if env_name and env_name not in names:
+            names.append(env_name)
+    return names
+
+
+def _inline_model_provider_secret_patch(
+    model_cfg: Dict[str, Any],
+    *,
+    raw_provider: str,
+    provider_key: str,
+) -> Tuple[Dict[str, str], str]:
+    api_key = model_cfg.get("api_key")
+    if _has_usable_secret(api_key):
+        return {"api_key": str(api_key).strip()}, "api_key"
+
+    for key in ("key_env", "api_key_env"):
+        raw = model_cfg.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return {"key_env": raw.strip()}, key
+
+    get_env_value = getattr(_cfg(), "get_env_value_prefer_dotenv", _cfg().get_env_value)
+    for env_name in _inline_provider_env_candidates(raw_provider, provider_key):
+        try:
+            value = get_env_value(env_name)
+        except Exception:
+            value = None
+        if _has_usable_secret(value):
+            return {"key_env": env_name}, env_name
+    return {}, ""
+
+
+def _matching_inline_provider_key(
+    providers: Dict[str, Any],
+    provider_value: str,
+    provider_key: str,
+) -> Optional[str]:
+    wanted_aliases = _inline_model_provider_aliases(
+        provider_value
+    ) | _inline_model_provider_aliases(provider_key)
+    if not wanted_aliases:
+        return None
+    for key, entry in providers.items():
+        aliases = _inline_model_provider_aliases(str(key or ""))
+        if isinstance(entry, dict):
+            aliases |= _inline_model_provider_aliases(str(entry.get("name") or ""))
+        if aliases & wanted_aliases:
+            return str(key)
+    return None
+
+
+def _legacy_inline_provider_already_configured(
+    config: Dict[str, Any],
+    provider_value: str,
+    provider_key: str,
+) -> bool:
+    wanted_aliases = _inline_model_provider_aliases(
+        provider_value
+    ) | _inline_model_provider_aliases(provider_key)
+    if not wanted_aliases:
+        return False
+    try:
+        compatible = _cfg().get_compatible_custom_providers(config)
+    except Exception:
+        compatible = []
+    for entry in compatible or []:
+        if not isinstance(entry, dict):
+            continue
+        aliases = _inline_model_provider_aliases(str(entry.get("name") or ""))
+        aliases |= _inline_model_provider_aliases(str(entry.get("provider_key") or ""))
+        if aliases & wanted_aliases:
+            return True
+    return False
+
+
+def _build_inline_model_provider_entry(
+    model_cfg: Dict[str, Any],
+    *,
+    raw_provider: str,
+    provider_key: str,
+    base_url: str,
+) -> Optional[Dict[str, Any]]:
+    entry: Dict[str, Any] = {
+        "name": provider_key,
+        "base_url": base_url,
+    }
+    secret_patch, _ = _inline_model_provider_secret_patch(
+        model_cfg,
+        raw_provider=raw_provider,
+        provider_key=provider_key,
+    )
+    entry.update(secret_patch)
+
+    api_mode = model_cfg.get("api_mode")
+    valid_api_modes = {
+        "chat_completions",
+        "codex_responses",
+        "anthropic_messages",
+        "bedrock_converse",
+        "codex_app_server",
+    }
+    if isinstance(api_mode, str) and api_mode.strip().lower() in valid_api_modes:
+        entry["api_mode"] = api_mode.strip().lower()
+
+    model_name = model_cfg.get("default") or model_cfg.get("model")
+    if isinstance(model_name, str) and model_name.strip():
+        entry["model"] = model_name.strip()
+
+    for key in (
+        "models",
+        "context_length",
+        "rate_limit_delay",
+        "discover_models",
+        "extra_body",
+        "extra_headers",
+        "ssl_ca_cert",
+        "ssl_verify",
+    ):
+        if key in model_cfg:
+            entry[key] = copy.deepcopy(model_cfg[key])
+
+    return _cfg()._custom_provider_entry_to_provider_config(
+        entry,
+        provider_key=provider_key,
+    )
+
+
+def _repair_inline_model_provider_config(
+    config: Dict[str, Any],
+) -> Optional[Tuple[str, str]]:
+    model_cfg = config.get("model")
+    if not isinstance(model_cfg, dict):
+        return None
+
+    raw_provider = model_cfg.get("provider")
+    if not isinstance(raw_provider, str) or not raw_provider.strip():
+        return None
+    if not _inline_model_provider_should_recover(raw_provider):
+        return None
+
+    base_url = _inline_model_base_url(model_cfg)
+    if not base_url:
+        return None
+
+    provider_key = _provider_key_from_inline_model_provider(raw_provider, base_url)
+    providers = config.get("providers")
+    if not isinstance(providers, dict):
+        providers = {}
+
+    matched_key = _matching_inline_provider_key(providers, raw_provider, provider_key)
+    if matched_key:
+        entry = providers.get(matched_key)
+        if not isinstance(entry, dict):
+            return None
+        if _provider_entry_has_secret(entry):
+            return None
+        secret_patch, source = _inline_model_provider_secret_patch(
+            model_cfg,
+            raw_provider=raw_provider,
+            provider_key=matched_key,
+        )
+        if not secret_patch:
+            return None
+        entry.update(secret_patch)
+        providers[matched_key] = entry
+        config["providers"] = providers
+        return matched_key, f"credential from {source}"
+
+    if _legacy_inline_provider_already_configured(config, raw_provider, provider_key):
+        return None
+
+    provider_entry = _build_inline_model_provider_entry(
+        model_cfg,
+        raw_provider=raw_provider,
+        provider_key=provider_key,
+        base_url=base_url,
+    )
+    if provider_entry is None:
+        return None
+    providers[provider_key] = provider_entry
+    config["providers"] = providers
+    return provider_key, "entry from model.provider"
+
+
+def _migrate_to_34(results: Dict[str, Any], quiet: bool) -> None:
+    # ── Version 33 → 34: recover Desktop inline named-custom model providers ──
+    # Desktop model selection could persist model.provider=packycode together
+    # with model.base_url/model.api_mode/model.api_key. Runtime resolution
+    # prefers providers.packycode when it exists, so repair both missing entries
+    # and existing entries that lack a credential source.
+    _c = _cfg()
+    read_raw_config = _c.read_raw_config
+    _persist_migration = _c._persist_migration
+
+    config = read_raw_config()
+    repaired = _repair_inline_model_provider_config(config)
+    if repaired is None:
+        return
+
+    provider_key, action = repaired
+    _persist_migration(config)
+    results["config_added"].append(
+        f"providers.{provider_key} ({action})"
+    )
+    if not quiet:
+        print(f"  ✓ Repaired providers.{provider_key} from inline model settings")
+
+
 #: Registry of (target_version, migration_fn), strictly ascending. The driver
 #: applies every entry whose target version is greater than the on-disk
 #: version captured before the ladder started. Order matters: later steps may
@@ -689,6 +993,7 @@ MIGRATIONS: Tuple[Tuple[int, Callable[[Dict[str, Any], bool], None]], ...] = (
     (31, _migrate_to_31),
     (32, _migrate_to_32),
     (33, _migrate_to_33),
+    (34, _migrate_to_34),
 )
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -635,6 +635,208 @@ def _try_resolve_from_custom_pool(
         return None
 
 
+def _inline_model_provider_aliases(value: str) -> set[str]:
+    normalized = _normalize_custom_provider_name(value or "")
+    if not normalized:
+        return set()
+    aliases = set(custom_provider_aliases(normalized, normalized))
+    if normalized.startswith("custom:"):
+        suffix = normalized.split(":", 1)[1].strip()
+        if suffix:
+            aliases.add(suffix)
+            aliases.add(f"custom:{suffix}")
+    else:
+        aliases.add(f"custom:{normalized}")
+    return {alias.strip().lower() for alias in aliases if alias}
+
+
+def _inline_model_provider_matches(requested_provider: str, configured_provider: str) -> bool:
+    requested_aliases = _inline_model_provider_aliases(requested_provider)
+    configured_aliases = _inline_model_provider_aliases(configured_provider)
+    return bool(
+        requested_aliases
+        and configured_aliases
+        and requested_aliases & configured_aliases
+    )
+
+
+def _inline_custom_pool_key(requested_provider: str) -> str:
+    requested_norm = _normalize_custom_provider_name(requested_provider or "")
+    if not requested_norm or requested_norm in {"auto", "custom", "moa"}:
+        return ""
+    if requested_norm.startswith("custom:"):
+        suffix = requested_norm.split(":", 1)[1].strip()
+        if not suffix:
+            return ""
+        return f"custom:{_normalize_custom_provider_name(suffix)}"
+    return f"custom:{requested_norm}"
+
+
+def _inline_provider_env_name(value: str) -> str:
+    raw = _normalize_custom_provider_name(value or "")
+    if raw.startswith("custom:"):
+        raw = raw.split(":", 1)[1].strip()
+    chars = [ch.upper() if ch.isalnum() else "_" for ch in raw]
+    name = "".join(chars).strip("_")
+    while "__" in name:
+        name = name.replace("__", "_")
+    if not name or not name[0].isalpha():
+        return ""
+    return f"{name}_API_KEY"
+
+
+def _inline_provider_env_candidates(requested_provider: str, configured_provider: str) -> list[str]:
+    names: list[str] = []
+    for value in (requested_provider, configured_provider):
+        env_name = _inline_provider_env_name(value)
+        if env_name and env_name not in names:
+            names.append(env_name)
+    return names
+
+
+def _inline_model_base_url(model_cfg: Dict[str, Any]) -> str:
+    for key in ("base_url", "url", "api"):
+        raw = model_cfg.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip().rstrip("/")
+    return ""
+
+
+def _inline_model_api_key_candidates(
+    *,
+    requested_provider: str,
+    base_url: str,
+) -> list[str]:
+    model_cfg = _get_model_config()
+    cfg_provider = str(model_cfg.get("provider") or "").strip()
+    if not _inline_model_provider_matches(requested_provider, cfg_provider):
+        return []
+
+    cfg_base_url = _inline_model_base_url(model_cfg)
+    if cfg_base_url and base_url and _normalize_base_url_for_match(cfg_base_url) != _normalize_base_url_for_match(base_url):
+        return []
+
+    key_env = ""
+    for key in ("key_env", "api_key_env"):
+        raw = model_cfg.get(key)
+        if isinstance(raw, str) and raw.strip():
+            key_env = raw.strip()
+            break
+
+    candidates = [
+        str(model_cfg.get("api_key") or "").strip(),
+        (_getenv(key_env, "").strip() if key_env else ""),
+    ]
+    for env_name in _inline_provider_env_candidates(requested_provider, cfg_provider):
+        candidates.append(_getenv(env_name, "").strip())
+    return candidates
+
+
+def _custom_endpoint_allows_no_key(base_url: str) -> bool:
+    host = base_url_hostname(base_url)
+    return bool(host and _loopback_hostname(host))
+
+
+def _raise_missing_named_custom_key(
+    *,
+    requested_provider: str,
+    provider_name: str,
+    base_url: str,
+) -> None:
+    raise AuthError(
+        f"Custom provider {provider_name!r} is missing api_key/key_env. "
+        f"Set providers.{requested_provider}.api_key or providers.{requested_provider}.key_env.",
+        provider=requested_provider,
+        code="missing_api_key",
+    )
+
+
+def _try_resolve_inline_model_custom_runtime(
+    *,
+    requested_provider: str,
+    explicit_api_key: Optional[str] = None,
+    explicit_base_url: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Resolve legacy Desktop configs that stored a named custom endpoint inline."""
+    requested_norm = (requested_provider or "").strip().lower()
+    if not requested_norm or requested_norm in {"auto", "custom", "moa"}:
+        return None
+    if not requested_norm.startswith("custom:") and auth_mod.is_runtime_provider_routable(requested_norm):
+        return None
+
+    model_cfg = _get_model_config()
+    cfg_provider = str(model_cfg.get("provider") or "").strip()
+    if not _inline_model_provider_matches(requested_provider, cfg_provider):
+        return None
+
+    base_url = (explicit_base_url or "").strip().rstrip("/")
+    if not base_url:
+        base_url = _inline_model_base_url(model_cfg)
+    if not base_url:
+        return None
+
+    api_mode = (
+        _parse_api_mode(model_cfg.get("api_mode"))
+        or _detect_api_mode_for_url(base_url)
+        or "chat_completions"
+    )
+
+    pool_key = _inline_custom_pool_key(requested_provider)
+    if pool_key:
+        try:
+            pool = load_pool(pool_key)
+            if pool and pool.has_credentials():
+                entry = pool.select()
+                pool_api_key = ""
+                if entry is not None:
+                    pool_api_key = (
+                        getattr(entry, "runtime_api_key", None)
+                        or getattr(entry, "access_token", "")
+                    )
+                if pool_api_key:
+                    return {
+                        "provider": "custom",
+                        "api_mode": api_mode,
+                        "base_url": base_url,
+                        "api_key": pool_api_key,
+                        "source": f"pool:{pool_key}",
+                        "credential_pool": pool,
+                        "requested_provider": requested_provider,
+                    }
+        except Exception:
+            pass
+
+    api_key_candidates = [
+        (explicit_api_key or "").strip(),
+        *_inline_model_api_key_candidates(
+            requested_provider=requested_provider,
+            base_url=base_url,
+        ),
+        _host_derived_api_key(base_url),
+    ]
+    api_key = next(
+        (candidate for candidate in api_key_candidates if has_usable_secret(candidate)),
+        "",
+    )
+    if not api_key and api_mode == "anthropic_messages" and not _custom_endpoint_allows_no_key(base_url):
+        _raise_missing_named_custom_key(
+            requested_provider=requested_provider,
+            provider_name=requested_provider,
+            base_url=base_url,
+        )
+    if not api_key:
+        api_key = "no-key-required"
+
+    return {
+        "provider": "custom",
+        "api_mode": api_mode,
+        "base_url": base_url,
+        "api_key": api_key,
+        "source": "inline-model-provider",
+        "requested_provider": requested_provider,
+    }
+
+
 def _lift_max_output_tokens(entry: Dict[str, Any], result: Dict[str, Any]) -> None:
     """Propagate a per-provider output cap onto the resolved runtime dict.
 
@@ -1138,6 +1340,10 @@ def _resolve_named_custom_runtime(
         (explicit_api_key or "").strip(),
         str(custom_provider.get("api_key", "") or "").strip(),
         _getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
+        *_inline_model_api_key_candidates(
+            requested_provider=requested_provider,
+            base_url=base_url,
+        ),
         # Gate provider env keys on their authoritative hosts — sending
         # OPENAI_API_KEY to a local-llm endpoint leaks credentials (#28660).
         (_getenv("OPENAI_API_KEY", "").strip()     if _cp_is_openai_url  else ""),
@@ -1147,12 +1353,21 @@ def _resolve_named_custom_runtime(
         _host_derived_api_key(base_url),
     ]
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
+    api_mode = (
+        custom_provider.get("api_mode")
+        or _detect_api_mode_for_url(base_url)
+        or "chat_completions"
+    )
+    if not api_key and api_mode == "anthropic_messages" and not _custom_endpoint_allows_no_key(base_url):
+        _raise_missing_named_custom_key(
+            requested_provider=requested_provider,
+            provider_name=str(custom_provider.get("name") or requested_provider),
+            base_url=base_url,
+        )
 
     result = {
         "provider": "custom",
-        "api_mode": custom_provider.get("api_mode")
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": api_mode,
         "base_url": base_url,
         "api_key": api_key or "no-key-required",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
@@ -1773,6 +1988,15 @@ def resolve_runtime_provider(
     if custom_runtime:
         custom_runtime["requested_provider"] = requested_provider
         return custom_runtime
+
+    inline_custom_runtime = _try_resolve_inline_model_custom_runtime(
+        requested_provider=requested_provider,
+        explicit_api_key=explicit_api_key,
+        explicit_base_url=explicit_base_url,
+    )
+    if inline_custom_runtime:
+        inline_custom_runtime["requested_provider"] = requested_provider
+        return inline_custom_runtime
 
     # If provider is "auto" (or unset) but config.yaml has an explicit base_url
     # pointing at a custom/local endpoint (e.g. Ollama at localhost:11434),

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -122,6 +122,56 @@ class TestResolveProviderClientNamedCustom:
         assert client is not None
         # no-key-required should be used
 
+    def test_named_custom_provider_inherits_main_key_for_same_host(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {
+                "default": "claude-opus-5",
+                "provider": "packycode",
+                "base_url": "https://www.packyapi.ai",
+                "api_key": "sk-inline",
+            },
+            "providers": {
+                "packycode": {
+                    "name": "PackyCode",
+                    "api": "https://www.packyapi.ai",
+                    "transport": "chat_completions",
+                    "default_model": "claude-opus-5",
+                },
+            },
+        })
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, model = resolve_provider_client("packycode", "claude-opus-5")
+
+        assert client is not None
+        assert model == "claude-opus-5"
+        assert mock_openai.call_args.kwargs["api_key"] == "sk-inline"
+
+    def test_named_custom_anthropic_messages_without_key_returns_none(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {
+                "default": "claude-opus-5",
+                "provider": "packycode",
+                "base_url": "https://www.packyapi.ai",
+            },
+            "providers": {
+                "packycode": {
+                    "name": "PackyCode",
+                    "api": "https://www.packyapi.ai",
+                    "transport": "anthropic_messages",
+                    "default_model": "claude-opus-5",
+                },
+            },
+        })
+        from agent.auxiliary_client import resolve_provider_client
+
+        client, model = resolve_provider_client("packycode", "claude-opus-5")
+
+        assert client is None
+        assert model is None
+
 
 
 class TestResolveProviderClientModelNormalization:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1401,6 +1401,180 @@ class TestDelegationCapUnificationMigration:
         assert "delegation" not in raw
 
 
+class TestInlineModelProviderRecoveryMigration:
+    """v33 → v34: recover Desktop inline named-custom provider configs."""
+
+    def _write(self, tmp_path, data):
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump(data),
+            encoding="utf-8",
+        )
+
+    def test_recovers_packycode_provider_from_model_endpoint(self, tmp_path):
+        self._write(
+            tmp_path,
+            {
+                "_config_version": 33,
+                "model": {
+                    "provider": "packycode",
+                    "default": "claude-opus-5",
+                    "base_url": "https://www.packyapi.ai",
+                    "api_mode": "anthropic_messages",
+                    "api_key": "sk-packy",
+                    "context_length": 1000000,
+                },
+            },
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+
+        assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+        provider = raw["providers"]["packycode"]
+        assert provider["api"] == "https://www.packyapi.ai"
+        assert provider["transport"] == "anthropic_messages"
+        assert provider["default_model"] == "claude-opus-5"
+        assert provider["api_key"] == "sk-packy"
+        assert provider["context_length"] == 1000000
+        assert raw["model"]["api_key"] == "sk-packy"
+
+    def test_repairs_existing_provider_missing_secret_from_inline_key(self, tmp_path):
+        self._write(
+            tmp_path,
+            {
+                "_config_version": 33,
+                "model": {
+                    "provider": "packycode",
+                    "default": "claude-opus-5",
+                    "base_url": "https://www.packyapi.com",
+                    "api_mode": "anthropic_messages",
+                    "api_key": "sk-inline",
+                },
+                "providers": {
+                    "packycode": {
+                        "name": "PackyCode",
+                        "api": "https://www.packyapi.ai",
+                        "transport": "anthropic_messages",
+                        "default_model": "claude-opus-5",
+                    }
+                },
+            },
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+
+        provider = raw["providers"]["packycode"]
+        assert provider["api"] == "https://www.packyapi.ai"
+        assert provider["transport"] == "anthropic_messages"
+        assert provider["api_key"] == "sk-inline"
+
+    def test_does_not_overwrite_existing_provider_api_key(self, tmp_path):
+        self._write(
+            tmp_path,
+            {
+                "_config_version": 33,
+                "model": {
+                    "provider": "packycode",
+                    "default": "claude-opus-5",
+                    "base_url": "https://www.packyapi.ai",
+                    "api_key": "sk-inline",
+                },
+                "providers": {
+                    "packycode": {
+                        "api": "https://existing.example.com/v1",
+                        "api_key": "sk-existing",
+                    }
+                },
+            },
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+
+        provider = raw["providers"]["packycode"]
+        assert provider["api"] == "https://existing.example.com/v1"
+        assert provider["api_key"] == "sk-existing"
+
+    def test_does_not_overwrite_existing_provider_key_env(self, tmp_path):
+        self._write(
+            tmp_path,
+            {
+                "_config_version": 33,
+                "model": {
+                    "provider": "packycode",
+                    "base_url": "https://www.packyapi.ai",
+                    "api_key": "sk-inline",
+                },
+                "providers": {
+                    "packycode": {
+                        "api": "https://www.packyapi.ai",
+                        "key_env": "PACKY_EXISTING_KEY",
+                    }
+                },
+            },
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+
+        provider = raw["providers"]["packycode"]
+        assert provider["key_env"] == "PACKY_EXISTING_KEY"
+        assert "api_key" not in provider
+
+    def test_repairs_existing_provider_from_dotenv_key_env(self, tmp_path):
+        self._write(
+            tmp_path,
+            {
+                "_config_version": 33,
+                "model": {
+                    "provider": "packycode",
+                    "default": "claude-opus-5",
+                    "base_url": "https://www.packyapi.ai",
+                },
+                "providers": {
+                    "packycode": {
+                        "api": "https://www.packyapi.ai",
+                        "transport": "anthropic_messages",
+                    }
+                },
+            },
+        )
+        (tmp_path / ".env").write_text("PACKYCODE_API_KEY=sk-dotenv\n", encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=True):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+
+        provider = raw["providers"]["packycode"]
+        assert provider["key_env"] == "PACKYCODE_API_KEY"
+        assert "api_key" not in provider
+
+    def test_builtin_provider_is_not_recovered(self, tmp_path):
+        self._write(
+            tmp_path,
+            {
+                "_config_version": 33,
+                "model": {
+                    "provider": "openrouter",
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "api_key": "sk-openrouter",
+                },
+            },
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+
+        assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+        assert "providers" not in raw
+
+
 class TestConfigNormalizationDoesNotOverwriteUserValues:
     """Regression tests for #27354."""
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -96,6 +96,7 @@ def test_qwen_oauth_auto_fallthrough_on_auth_failure(monkeypatch):
         "resolve_qwen_runtime_credentials",
         lambda **kw: (_ for _ in ()).throw(AuthError("stale", provider="qwen-oauth", code="qwen_auth_missing")),
     )
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: SimpleNamespace(has_credentials=lambda: False))
     monkeypatch.setattr(rp, "_get_model_config", lambda: {})
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-or-key")
 
@@ -585,6 +586,119 @@ def test_named_custom_provider_uses_saved_credentials(monkeypatch):
     assert resolved["api_key"] == "local-provider-key"
     assert resolved["requested_provider"] == "local"
     assert resolved["source"] == "custom_provider:Local"
+
+
+def test_named_custom_provider_uses_inline_model_key_when_entry_missing_secret(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("PACKYCODE_API_KEY", raising=False)
+    monkeypatch.delenv("PACKYAPI_API_KEY", raising=False)
+    model_cfg = {
+        "provider": "packycode",
+        "default": "claude-opus-5",
+        "base_url": "https://www.packyapi.ai",
+        "api_key": "sk-inline",
+    }
+    cfg = {
+        "model": model_cfg,
+        "providers": {
+            "packycode": {
+                "name": "PackyCode",
+                "api": "https://www.packyapi.ai",
+                "transport": "anthropic_messages",
+                "default_model": "claude-opus-5",
+            }
+        },
+    }
+    monkeypatch.setattr(rp, "_get_model_config", lambda: model_cfg)
+    monkeypatch.setattr(rp, "load_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: SimpleNamespace(provider=provider, has_credentials=lambda: False),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="packycode")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["requested_provider"] == "packycode"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://www.packyapi.ai"
+    assert resolved["api_key"] == "sk-inline"
+    assert resolved["source"] == "custom_provider:PackyCode"
+
+
+def test_named_custom_anthropic_messages_without_key_fails_locally(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("PACKYCODE_API_KEY", raising=False)
+    monkeypatch.delenv("PACKYAPI_API_KEY", raising=False)
+    model_cfg = {
+        "provider": "packycode",
+        "default": "claude-opus-5",
+        "base_url": "https://www.packyapi.ai",
+    }
+    cfg = {
+        "model": model_cfg,
+        "providers": {
+            "packycode": {
+                "name": "PackyCode",
+                "api": "https://www.packyapi.ai",
+                "transport": "anthropic_messages",
+                "default_model": "claude-opus-5",
+            }
+        },
+    }
+    monkeypatch.setattr(rp, "_get_model_config", lambda: model_cfg)
+    monkeypatch.setattr(rp, "load_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: SimpleNamespace(provider=provider, has_credentials=lambda: False),
+    )
+
+    with pytest.raises(rp.AuthError, match="missing api_key/key_env"):
+        rp.resolve_runtime_provider(requested="packycode")
+
+
+def test_inline_unknown_model_provider_resolves_as_custom(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("PACKYCODE_API_KEY", raising=False)
+    monkeypatch.delenv("PACKYAPI_API_KEY", raising=False)
+    model_cfg = {
+        "provider": "packycode",
+        "default": "claude-opus-5",
+        "base_url": "https://www.packyapi.ai",
+        "api_mode": "anthropic_messages",
+        "api_key": "sk-packy",
+    }
+    monkeypatch.setattr(rp, "_get_model_config", lambda: model_cfg)
+    monkeypatch.setattr(rp, "load_config", lambda: {"model": model_cfg})
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": model_cfg})
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: SimpleNamespace(provider=provider, has_credentials=lambda: False),
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("inline model provider recovery should run before resolve_provider")
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider()
+
+    assert resolved["provider"] == "custom"
+    assert resolved["requested_provider"] == "packycode"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://www.packyapi.ai"
+    assert resolved["api_key"] == "sk-packy"
+    assert resolved["source"] == "inline-model-provider"
 
 
 def test_bare_custom_resolves_providers_dict_entry_named_custom(monkeypatch):


### PR DESCRIPTION
## 摘要
- 新增配置 schema 34，覆盖升级时把 inline 自定义 provider 转成 providers 条目，并补齐缺失密钥来源
- named custom provider 运行时兜底读取 inline model key/env，缺少远程 anthropic_messages 密钥时本地失败，避免 Bearer None
- 辅助模型 client 对同 host named custom provider 复用主配置密钥，缺密钥时不构造无效客户端

## 测试
- pytest tests/hermes_cli/test_config.py -k InlineModelProviderRecoveryMigration
- pytest tests/hermes_cli/test_runtime_provider_resolution.py -k "named_custom_provider_uses_inline_model_key_when_entry_missing_secret or named_custom_anthropic_messages_without_key_fails_locally or inline_unknown_model_provider_resolves_as_custom"
- pytest tests/agent/test_auxiliary_named_custom_providers.py -k "inherits_main_key or anthropic_messages_without_key"
- ruff check hermes_cli/config_defaults.py hermes_cli/config_migrations.py hermes_cli/runtime_provider.py agent/auxiliary_client.py tests/hermes_cli/test_config.py tests/hermes_cli/test_runtime_provider_resolution.py tests/agent/test_auxiliary_named_custom_providers.py