### PR TITLE
fix(auth): write auth.json as pure ASCII so GBK readers don't wipe it

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1253,7 +1253,15 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
     secure_parent_dir(auth_file)
     auth_store["version"] = AUTH_STORE_VERSION
     auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
-    payload = orjson.dumps(auth_store, option=orjson.OPT_INDENT_2).decode('utf-8') + "\n"
+    # Use stdlib json.dumps with ensure_ascii=True (NOT orjson, which never
+    # escapes non-ASCII). orjson writes raw UTF-8 bytes; on Chinese Windows
+    # the default locale codec is GBK, so a later reader that does not pass
+    # encoding="utf-8" crashes with "'gbk' codec can't decode byte ..." and
+    # the store is treated as corrupt (see hermes_cli.auth._load_auth_store).
+    # auth.json is a low-frequency credential store — stdlib serialization
+    # cost is irrelevant, and pure-ASCII output is parseable under every
+    # codec (UTF-8, GBK, ASCII).
+    payload = json.dumps(auth_store, ensure_ascii=True, indent=2) + "\n"
     tmp_path = auth_file.with_name(f"{auth_file.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
     try:
         # Create with 0o600 atomically via os.open(O_EXCL) + fdopen to close


### PR DESCRIPTION
## Problem

On Chinese Windows, `auth.json` gets wiped as "corrupt" whenever a configured provider has a **Chinese name**.

Repro: `config.yaml` defines `custom:tokenrhythm-studio` with `name: 基元律动`. The credential pool persists the pool key as `custom:基元律动`. Because `_save_auth_store` uses `orjson.dumps` — which **never escapes non-ASCII** — the Chinese name is written as raw UTF-8 bytes.

On zh-CN Windows the default locale codec is **GBK**, so any reader that does not pass `encoding="utf-8"` (e.g. the packaged desktop runtime 0.19.0-cn.7) fails in `_load_auth_store`:

```
WARNING hermes_cli.auth: auth: failed to parse ...\auth.json ('gbk' codec can't decode byte 0xaf in position 86: illegal multibyte sequence) — starting with empty store. Corrupt file preserved at auth.json.corrupt
```

Worse, even when GBK decoding happens to succeed, the key is silently mangled: `custom:基元律动` → `custom:鍩哄厓寰嬪姩` (mojibake), duplicating pool entries.

## Root cause

`_save_auth_store` (hermes_cli/auth.py:1256) was switched from upstream's stdlib `json.dumps` (default `ensure_ascii=True`) to `orjson.dumps(...).decode('utf-8')`. orjson is faster but **always emits raw UTF-8 for non-ASCII** — there is no ASCII-escaping option (`orjson.OPT_ASCII` does not exist). Upstream NousResearch/hermes-agent still uses `json.dumps(auth_store, indent=2)` for exactly this reason.

## Fix

Restore upstream behavior in `_save_auth_store`:

```python
payload = json.dumps(auth_store, ensure_ascii=True, indent=2) + "\n"
```

`auth.json` is a low-frequency credential store; stdlib serialization cost is irrelevant. Pure-ASCII output is parseable under **every** codec (UTF-8, GBK, ASCII), so both current readers (`encoding="utf-8"`) and older readers (locale-default GBK) are safe.

## Verification

Repro script (stdlib `json.dumps(ensure_ascii=True)` vs `orjson.dumps`), writing a store containing `custom:基元律动` to a UTF-8 file then reading it with the **default GBK codec** (simulating the old reader):

```
FIXED: GBK-default read OK  keys=['custom:基元律动']
OLD : GBK-default read OK  keys=['custom:鍩哄厓寰嬪姩']   # mojibake, or crash on other bytes
```

Also verified locally: the affected `auth.json` (containing both `custom:基元律动` and the mojibake duplicate) parses cleanly under both UTF-8 and GBK after conversion, and the corrupted store was restored from its `.corrupt` backup.
