### PR TITLE
test: 修复主分支 CI 时序抖动

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4215,6 +4215,7 @@ async function ensureRuntime(backend) {
             'and ensure it is on your PATH to use Git Bash, or keep the default shell "auto".'
         )
       }
+
       // Verify at least one PowerShell is available (ships with every Windows system).
       const hasPowerShell =
         findOnPath('pwsh.exe') ||

--- a/tests/performance/test_cron_scheduler.py
+++ b/tests/performance/test_cron_scheduler.py
@@ -183,12 +183,13 @@ def test_load_jobs_cached_fast(timing_context, tmp_path, monkeypatch, sample_job
 
 @pytest.mark.perf
 def test_tick_cycles_benchmark(timing_context, tmp_path, monkeypatch):
-    """100 real cron tick cycles (empty schedule) complete quickly.
+    """Benchmark 100 real cron tick cycles and pin the cache-hit contract.
 
     Exercises the real tick file lock + jobs lock + cached get_due_jobs/load_jobs
-    path; only load_config (a separate perf domain) is stubbed. Plan target is
-    < 50 ms for 100 cycles — we report whether it was met and gate on a
-    contention-safe ceiling so the test is not flaky under parallel CI load.
+    path; only load_config (a separate perf domain) is stubbed. The < 50 ms
+    target remains diagnostic because shared-runner wall time varies with host
+    contention. The deterministic gate is that every warmed tick stays on the
+    cache-hit path and an empty schedule never dispatches a job.
     """
     from cron import scheduler as cron_sched
 
@@ -202,11 +203,21 @@ def test_tick_cycles_benchmark(timing_context, tmp_path, monkeypatch):
     # Warm up: first tick creates the lock file and primes the read cache.
     cron_sched.tick(verbose=True, sync=True)
 
+    parse_calls = []
+    real_json_load = cron_jobs.json.load
+
+    def counting_json_load(*args, **kwargs):
+        parse_calls.append(1)
+        return real_json_load(*args, **kwargs)
+
+    monkeypatch.setattr(cron_jobs.json, "load", counting_json_load)
+
     # Best-of-3 batches: filters transient GC/scheduler noise on shared runners.
+    tick_results = []
     for _ in range(3):
         with timing_context.measure("tick_100x"):
             for _ in range(100):
-                cron_sched.tick(verbose=True, sync=True)
+                tick_results.append(cron_sched.tick(verbose=True, sync=True))
 
     durations = timing_context.summary().get("tick_100x", {}).get("durations", [0])
     best_ms = min(durations)
@@ -215,7 +226,5 @@ def test_tick_cycles_benchmark(timing_context, tmp_path, monkeypatch):
         f"\n  100 tick cycles (best of {len(durations)}): {best_ms:.1f}ms "
         f"[<50ms target: {target_met}]  batches={[round(d, 1) for d in durations]}"
     )
-    assert best_ms < 150, (
-        f"100 tick cycles took {best_ms:.1f}ms (expected well under 150ms; "
-        f"a cache/syscall regression is the likely cause)"
-    )
+    assert tick_results == [0] * 300
+    assert parse_calls == [], "warmed cron ticks must not re-parse an unchanged jobs.json"

--- a/tests/tools/test_zombie_process_cleanup.py
+++ b/tests/tools/test_zombie_process_cleanup.py
@@ -477,6 +477,21 @@ class TestDelegationCleanup:
         monkeypatch.setattr(relay_runtime, "get_runtime", lambda **_kwargs: relay_host)
         monkeypatch.setattr("tools.delegate_tool._get_child_timeout", lambda: 0.1)
 
+        from tools.daemon_pool import DaemonThreadPoolExecutor
+
+        real_submit = DaemonThreadPoolExecutor.submit
+
+        def submit_after_child_starts(executor, *args, **kwargs):
+            future = real_submit(executor, *args, **kwargs)
+            assert child_started.wait(timeout=5)
+            return future
+
+        monkeypatch.setattr(
+            DaemonThreadPoolExecutor,
+            "submit",
+            submit_after_child_starts,
+        )
+
         def run_conversation(**kwargs):
             lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
                 profile_key=relay_runtime.current_profile_key(),

--- a/tests/tui_gateway/test_slash_worker_mcp_discovery.py
+++ b/tests/tui_gateway/test_slash_worker_mcp_discovery.py
@@ -90,9 +90,9 @@ def test_profile_local_mcp_tool_is_visible_in_slash_worker(tmp_path):
         proc.stdin.write(json.dumps({"id": 1, "command": "/tools"}) + "\n")
         proc.stdin.flush()
         try:
-            line = output.get(timeout=10)
+            line = output.get(timeout=30)
         except queue.Empty:
-            pytest.fail("slash worker produced no /tools response within 10 seconds")
+            pytest.fail("slash worker produced no /tools response within 30 seconds")
         response = json.loads(line)
         assert response["ok"] is True
         assert "mcp__profileprobe__hermes_61922_profile_probe" in response["output"]


### PR DESCRIPTION
## 变更

- 将 cron tick 性能测试从共享 Runner 上不稳定的固定 wall-clock 门槛，改为“热缓存不重新解析 jobs.json、空计划不派发任务”的确定性行为契约；耗时仍保留为诊断输出。
- 在线程超时测试开始计时前显式等待子线程进入会话，避免 0.1 秒启动窗口受调度负载影响。
- 将 slash worker 集成测试的进程响应超时从 10 秒放宽到 30 秒，保留真实进程/MCP 路径与超时保护。
- 应用主分支自动格式化工作流发现的 Desktop 空行修正。

## 原因

PR #156 合并后的主分支 CI 在 attempt 1 与 attempt 3 重复失败：

- `test_tick_cycles_benchmark` 在共享 Runner 上分别测得约 200 ms、233.5 ms，超过 150 ms 固定阈值；同一代码树本地为 21.9–35.8 ms，PR CI 也曾通过。
- `test_timed_out_child_keeps_relay_session_until_its_turn_exits` 的子线程在高负载下未能于 0.1 秒内启动。
- slash worker 测试两次首轮超过 10 秒，但内建重试均立即通过。

失败运行：https://github.com/Eynzof/Hermes-CN-Core/actions/runs/31657108679

## 影响

不改变生产代码行为。测试仍覆盖原有缓存、空任务派发、超时后 Relay 会话生命周期及 profile-local MCP 发现路径，但不再把共享 Runner 调度延迟误判为功能回归。

## 验证

- 相关 cron 与 Relay 目标测试：2 passed。
- Relay 超时测试连续运行 20 次：20/20 passed。
- slash worker MCP 集成测试：passed。
- `ruff check`（三个 Python 测试文件）：passed。
- `prettier --check apps/desktop/electron/main.ts`：passed。
- `git diff --check`：passed。
