### PR TITLE
ci: 修复 runtime 发布依赖解析

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -128,13 +128,35 @@ jobs:
         with:
           python-version: "3.14"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+        with:
+          version: "0.9.28"
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
       - name: Install build deps + agent
         shell: bash
         run: |
-          python -m pip install --upgrade pip
-          # Install the package plus dashboard extras into the build env so the
-          # frozen runtime never tries to lazy-install fastapi/uvicorn on a
-          # user's machine.
+          # Install the exact locked dependency set used by main CI. This must
+          # use uv rather than bare pip: the project intentionally overrides
+          # incompatible transitive caps (for example cryptography 50 with the
+          # current Alibaba SDK), and pip does not honor [tool.uv] overrides.
+          # A fresh pip resolution silently downgraded alibabacloud-tea-openapi
+          # and omitted darabonba-core, then PyInstaller failed while copying
+          # that package's metadata.
+          uv sync --locked --python 3.14 --extra cn-desktop
+
+          # Install packaging-only tooling into that same locked environment.
+          uv pip install --python .venv "pyinstaller==6.*"
+
+          # GITHUB_PATH applies to subsequent steps. Resolve the interpreter
+          # directory through uv so this is correct for POSIX bin/ and Windows
+          # Scripts/ layouts without maintaining two path branches.
+          uv run --no-sync python -c 'import os, sys; print(os.path.dirname(sys.executable))' >> "$GITHUB_PATH"
+
           # The `cn-desktop` aggregate extra pre-bakes every backend the frozen
           # runtime exposes: dashboard (web), the Anthropic transport (MiniMax-CN
           # rides on Anthropic Messages), the native MCP client (issue #16), and
@@ -144,9 +166,6 @@ jobs:
           # unavailable at runtime — and `pip install <pkg>` on the host does NOT
           # help, since the frozen runtime ships its own interpreter + packages.
           # Keep this in sync with the cn-desktop extra in pyproject.toml.
-          pip install -e ".[cn-desktop]"
-          # Build tooling
-          pip install pyinstaller==6.* cryptography
 
       - name: Set up Node.js (build web dashboard + TUI bundle)
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/tests/test_runtime_release_workflow.py
+++ b/tests/test_runtime_release_workflow.py
@@ -11,6 +11,7 @@ failure mode behind issue #16 (MCP) and the 飞书/钉钉/企微/微信 desktop 
 import os
 import plistlib
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -54,12 +55,29 @@ def _frozen_verify_packages() -> set[str]:
     return set(body.replace("\\", "").split())
 
 
-def test_runtime_workflow_installs_cn_desktop_extra():
-    """The frozen runtime installs the cn-desktop aggregate extra.
+def test_runtime_workflow_installs_cn_desktop_extra_from_lock():
+    """The frozen runtime installs the locked cn-desktop aggregate extra.
 
     cn-desktop is the single source of truth for "what the desktop ships".
+    Bare pip resolution is forbidden because it ignores ``[tool.uv]``
+    overrides and can silently select a different transitive dependency set.
     """
-    assert 'pip install -e ".[cn-desktop]"' in _workflow_text()
+    workflow = _workflow_text()
+    sync_commands = [
+        shlex.split(line.strip())
+        for line in workflow.splitlines()
+        if line.strip().startswith("uv sync ")
+    ]
+
+    assert any(
+        "--locked" in command
+        and any(
+            command[index : index + 2] == ["--extra", "cn-desktop"]
+            for index in range(len(command) - 1)
+        )
+        for command in sync_commands
+    ), "release-runtime.yml must install the locked cn-desktop extra with uv"
+    assert 'pip install -e ".[cn-desktop]"' not in workflow
 
 
 def test_runtime_workflow_python_satisfies_project_requirement():


### PR DESCRIPTION
## 问题

`runtime-v0.20.0-cn.6` 的四平台发布在 PyInstaller metadata 收集阶段失败。发布任务使用裸 `pip install`，没有应用 `[tool.uv]` 的依赖 override；`cryptography 50.0.0` 使 pip 回退到 `alibabacloud-tea-openapi 0.3.16`，从而漏装 `darabonba-core`。

失败流水线：https://github.com/Eynzof/Hermes-CN-Core/actions/runs/31859506192

## 修复

- 固定使用与主 CI 一致的 `setup-uv 0.9.28`
- 通过 `uv sync --locked --python 3.14 --extra cn-desktop` 安装锁定依赖
- 将 PyInstaller 安装到同一 `.venv`
- 把该虚拟环境的解释器目录加入后续步骤的 `GITHUB_PATH`

## 最小验证

- `uv lock --check`
- 实际创建 `cn-desktop` 环境并安装 PyInstaller
- 核对 `cryptography=50.0.0`、`alibabacloud-tea-openapi=0.4.5`、`darabonba-core=1.0.8`
- PyInstaller 成功读取 workflow 中全部 39 个 `--copy-metadata` 参数
- YAML 结构解析与 `git diff --check` 通过