### PR TITLE
fix: 补齐桌面运行时注册模块

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -427,6 +427,7 @@ exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = 
 # sealed venv is missing hermes_constants, run_agent, etc.
 py-modules = [
   "run_agent",
+  "registration_lifecycle",
   "model_tools",
   "toolsets",
   "batch_runner",

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -17,6 +17,18 @@ def _load_package_data():
     return tool["setuptools"]["package-data"]
 
 
+def _load_py_modules():
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject_path.open("rb") as handle:
+        tool = tomllib.load(handle)["tool"]
+    return tool["setuptools"]["py-modules"]
+
+
+def test_plugin_registration_lifecycle_is_packaged():
+    """The sealed wheel must contain every top-level plugin-loader import."""
+    assert "registration_lifecycle" in _load_py_modules()
+
+
 def test_matrix_extra_not_in_all():
     """The [matrix] extra pulls `mautrix[encryption]` -> `python-olm`,
     which has Linux-only wheels and no native build path on Windows or


### PR DESCRIPTION
补齐 setuptools 顶层模块清单中的 registration_lifecycle，避免密封桌面运行时安装后插件加载阶段导入失败。

验证：
- pytest -q --noconftest tests/test_project_metadata.py（8 passed）
- uvx ruff check tests/test_project_metadata.py
- 本地构建 wheel 并确认包含 registration_lifecycle.py
- Desktop 双仓真实 Core + fake model E2E（13 passed）