### PR TITLE
fix: 合并 dev-fix 语音配置元数据

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1117,6 +1117,60 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "ElevenLabs Scribe model",
         "options": ["scribe_v2", "scribe_v1"],
     },
+    # --- Voice provider fields (enriched from DEFAULT_CONFIG; options are
+    # UI guidance for the desktop/dashboard — the runtime accepts any value) ---
+    "stt.local.language": {
+        "type": "string",
+        "description": "Local Whisper language hint (blank = auto-detect; e.g. zh, en)",
+    },
+    "stt.elevenlabs.language_code": {
+        "type": "string",
+        "description": "ElevenLabs Scribe language code (blank = auto-detect; e.g. eng, zho)",
+    },
+    "stt.elevenlabs.tag_audio_events": {
+        "type": "boolean",
+        "description": "Tag audio events (music, laughter, etc.) in Scribe transcripts",
+    },
+    "stt.elevenlabs.diarize": {
+        "type": "boolean",
+        "description": "Speaker diarization for ElevenLabs Scribe",
+    },
+    "tts.edge.voice": {
+        "type": "string",
+        "description": "Edge TTS voice name (e.g. zh-CN-XiaoxiaoNeural)",
+    },
+    "tts.openai.model": {
+        "type": "select",
+        "description": "OpenAI TTS model",
+        "options": ["gpt-4o-mini-tts", "gpt-4o-tts", "tts-1", "tts-1-hd"],
+    },
+    "tts.openai.voice": {
+        "type": "select",
+        "description": "OpenAI TTS voice",
+        "options": [
+            "alloy", "ash", "ballad", "cedar", "coral", "echo", "fable",
+            "marin", "nova", "onyx", "sage", "shimmer", "verse",
+        ],
+    },
+    "tts.elevenlabs.voice_id": {
+        "type": "string",
+        "description": "ElevenLabs voice ID (dynamic list via /api/audio/elevenlabs/voices)",
+    },
+    "tts.elevenlabs.model_id": {
+        "type": "string",
+        "description": "ElevenLabs TTS model (e.g. eleven_multilingual_v2)",
+    },
+    "tts.neutts.device": {
+        "type": "select",
+        "description": "NeuTTS inference device",
+        "options": ["cpu", "cuda", "mps"],
+    },
+    "tts.xai.speed": {
+        "type": "number",
+        "description": "xAI playback speed (0.7-1.5)",
+        "minimum": 0.7,
+        "maximum": 1.5,
+    },
     "display.skin": {
         "type": "select",
         "description": "CLI visual theme",

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3035,7 +3035,55 @@ class TestBuildSchemaFromConfig:
         assert "python3.13" in runtime_entry["options"]
         assert len(runtime_entry["options"]) >= 3
 
+    def test_voice_provider_schema_overrides(self):
+        """Voice settings expose controls that match their runtime values."""
+        from hermes_cli.web_server import CONFIG_SCHEMA
 
+        expected_types = {
+            "stt.local.language": "string",
+            "stt.elevenlabs.language_code": "string",
+            "stt.elevenlabs.tag_audio_events": "boolean",
+            "stt.elevenlabs.diarize": "boolean",
+            "tts.edge.voice": "string",
+            "tts.openai.model": "select",
+            "tts.openai.voice": "select",
+            "tts.elevenlabs.voice_id": "string",
+            "tts.elevenlabs.model_id": "string",
+            "tts.neutts.device": "select",
+            "tts.xai.speed": "number",
+        }
+
+        for key, expected_type in expected_types.items():
+            assert CONFIG_SCHEMA[key]["type"] == expected_type
+
+        assert CONFIG_SCHEMA["tts.openai.model"]["options"] == [
+            "gpt-4o-mini-tts",
+            "gpt-4o-tts",
+            "tts-1",
+            "tts-1-hd",
+        ]
+        assert CONFIG_SCHEMA["tts.openai.voice"]["options"] == [
+            "alloy",
+            "ash",
+            "ballad",
+            "cedar",
+            "coral",
+            "echo",
+            "fable",
+            "marin",
+            "nova",
+            "onyx",
+            "sage",
+            "shimmer",
+            "verse",
+        ]
+        assert CONFIG_SCHEMA["tts.neutts.device"]["options"] == [
+            "cpu",
+            "cuda",
+            "mps",
+        ]
+        assert CONFIG_SCHEMA["tts.xai.speed"]["minimum"] == 0.7
+        assert CONFIG_SCHEMA["tts.xai.speed"]["maximum"] == 1.5
 
     def test_timezone_field_is_searchable_select(self):
         """timezone must ship as a searchable, clearable select of IANA ids.


### PR DESCRIPTION
保留并合入 d035b03b 的语音配置元数据，同时增加 11 个 STT/TTS 字段、候选值及 xAI speed 边界测试。