### PR TITLE
fix(installer): align Python selection with metadata and point fork installers at this repo

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -5,7 +5,7 @@
 # Uses uv for fast Python provisioning and package management.
 #
 # Usage:
-#   iex (irm https://hermes-agent.nousresearch.com/install.ps1)
+#   iex (irm https://raw.githubusercontent.com/Eynzof/Hermes-CN-Core/main/scripts/install.ps1)
 #
 # Or download and run with options:
 #   .\install.ps1 -NoVenv -SkipSetup
@@ -373,14 +373,13 @@ $script:ResolvedPathReport = @{
 # Configuration
 # ============================================================================
 
-$RepoUrlSsh = "git@github.com:NousResearch/hermes-agent.git"
-$RepoUrlHttps = "https://github.com/NousResearch/hermes-agent.git"
+$RepoUrlSsh = "git@github.com:Eynzof/Hermes-CN-Core.git"
+$RepoUrlHttps = "https://github.com/Eynzof/Hermes-CN-Core.git"
 $PythonVersion = "3.14"
-# Minor versions the installer accepts when the requested $PythonVersion isn't
-# available, in preference order.  uv discovers both uv-managed and system
-# interpreters, so this list also matches a pre-existing system Python.  Single
-# source of truth shared by Test-Python's fallback and Resolve-AvailablePythonVersion.
-$PythonFallbackVersions = @("3.12", "3.13", "3.10")
+# This fork requires Python >=3.14, so falling back to an older minor would
+# only defer failure until dependency installation. Keep the shared fallback
+# list empty; `uv python find 3.14` already accepts compatible patch releases.
+$PythonFallbackVersions = @()
 $NodeVersion = "22"
 # The npm range the root package.json pins in `engines.npm`.  A constant rather
 # than a manifest read like the POSIX side does: Test-Node runs BEFORE the repo
@@ -2366,13 +2365,13 @@ function Install-Repository {
                 # for.  GitHub supports archive URLs for commits, tags, and
                 # branches; we honour Commit > Tag > Branch.
                 if ($Commit) {
-                    $zipUrl = "https://github.com/NousResearch/hermes-agent/archive/$Commit.zip"
+                    $zipUrl = "https://github.com/Eynzof/Hermes-CN-Core/archive/$Commit.zip"
                     $zipLabel = $Commit
                 } elseif ($Tag) {
-                    $zipUrl = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/$Tag.zip"
+                    $zipUrl = "https://github.com/Eynzof/Hermes-CN-Core/archive/refs/tags/$Tag.zip"
                     $zipLabel = $Tag
                 } else {
-                    $zipUrl = "https://github.com/NousResearch/hermes-agent/archive/refs/heads/$Branch.zip"
+                    $zipUrl = "https://github.com/Eynzof/Hermes-CN-Core/archive/refs/heads/$Branch.zip"
                     $zipLabel = $Branch
                 }
                 $zipPath = "$env:TEMP\hermes-agent-$zipLabel.zip"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,7 +6,7 @@
 # Uses uv for desktop/server installs and Python's stdlib venv + pip on Termux.
 #
 # Usage:
-#   curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/Eynzof/Hermes-CN-Core/main/scripts/install.sh | bash
 #
 # Or with options:
 #   curl -fsSL ... | bash -s -- --no-venv --skip-setup
@@ -44,8 +44,8 @@ NC='\033[0m' # No Color
 BOLD='\033[1m'
 
 # Configuration
-REPO_URL_SSH="git@github.com:NousResearch/hermes-agent.git"
-REPO_URL_HTTPS="https://github.com/NousResearch/hermes-agent.git"
+REPO_URL_SSH="git@github.com:Eynzof/Hermes-CN-Core.git"
+REPO_URL_HTTPS="https://github.com/Eynzof/Hermes-CN-Core.git"
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
 HERMES_HOME_ARG_EXPLICIT=false
 # INSTALL_DIR is resolved AFTER arg parsing and OS detection so we can pick an

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -34,7 +34,7 @@ cd "$SCRIPT_DIR"
 # wrong user's home directory when running under sudo -u <user>.  See #21269.
 export UV_NO_CONFIG=1
 
-PYTHON_VERSION="3.11"
+PYTHON_VERSION="3.14"
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
 HERMES_HOME_ARG_EXPLICIT=false
 ISOLATED_LAYOUT=false
@@ -186,11 +186,11 @@ echo -e "${CYAN}→${NC} Checking Python $PYTHON_VERSION..."
 if is_termux; then
     if command -v python >/dev/null 2>&1; then
         PYTHON_PATH="$(command -v python)"
-        if "$PYTHON_PATH" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
+        if "$PYTHON_PATH" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 14) else 1)' 2>/dev/null; then
             PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
             echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION found"
         else
-            echo -e "${RED}✗${NC} Termux Python must be 3.11+"
+            echo -e "${RED}✗${NC} Termux Python must be 3.14+"
             echo "    Run: pkg install python"
             exit 1
         fi

--- a/tests/hermes_cli/test_setup_hermes_script.py
+++ b/tests/hermes_cli/test_setup_hermes_script.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 import subprocess
 import sys
 
@@ -22,3 +23,131 @@ def test_setup_hermes_script_has_termux_path():
     assert ".[termux]" in content
     assert "constraints-termux.txt" in content
     assert "$PREFIX/bin" in content
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="setup-hermes.sh is a POSIX shell script")
+def test_setup_hermes_script_requests_python_314(tmp_path):
+    script = tmp_path / "setup-hermes.sh"
+    script.write_text(SETUP_SCRIPT.read_text(encoding="utf-8"), encoding="utf-8")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    uv_log = tmp_path / "uv.log"
+    fake_python = fake_bin / "python314"
+    fake_python.write_text(
+        '#!/bin/sh\necho "Python 3.14.7"\n',
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/bin/sh
+printf '%s\\n' "$*" >> "$UV_LOG"
+case "$1" in
+  --version)
+    echo "uv 0.0.0-test"
+    exit 0
+    ;;
+  python)
+    if [ "$2" = "find" ]; then
+      printf '%s\n' "$FAKE_PYTHON"
+      exit 0
+    fi
+    ;;
+  venv)
+    mkdir -p "$PWD/venv/bin"
+    : > "$PWD/venv/bin/python"
+    chmod +x "$PWD/venv/bin/python"
+    exit 0
+    ;;
+  sync|pip)
+    exit 1
+    ;;
+esac
+exit 1
+""",
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+
+    env = dict(os.environ)
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "HOME": str(tmp_path / "home"),
+            "HERMES_HOME": str(tmp_path / "hermes-home"),
+            "UV_LOG": str(uv_log),
+            "FAKE_PYTHON": str(fake_python),
+        }
+    )
+    (tmp_path / "home").mkdir()
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    calls = uv_log.read_text(encoding="utf-8").splitlines()
+    assert "python find 3.14" in calls
+    assert "venv venv --python 3.14" in calls
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="setup-hermes.sh is a POSIX shell script")
+def test_setup_hermes_termux_rejects_python_313(tmp_path):
+    script = tmp_path / "setup-hermes.sh"
+    script.write_text(SETUP_SCRIPT.read_text(encoding="utf-8"), encoding="utf-8")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python"
+    fake_python.write_text(
+        f"""#!{sys.executable}
+import os
+import sys
+import types
+
+if len(sys.argv) >= 2 and sys.argv[1] == "-c":
+    real_sys = sys.modules["sys"]
+    fake_sys = types.ModuleType("sys")
+    fake_sys.version_info = (3, 13, 9)
+    sys.modules["sys"] = fake_sys
+    try:
+        exec(sys.argv[2], {{}})
+    finally:
+        sys.modules["sys"] = real_sys
+elif len(sys.argv) >= 2 and sys.argv[1] == "--version":
+    print("Python 3.13.9")
+else:
+    raise SystemExit(17)
+""",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    env = dict(os.environ)
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "HOME": str(tmp_path / "home"),
+            "HERMES_HOME": str(tmp_path / "hermes-home"),
+            "TERMUX_VERSION": "test",
+            "PREFIX": str(tmp_path / "termux-prefix"),
+        }
+    )
+    (tmp_path / "home").mkdir()
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "Termux Python must be 3.14+" in result.stdout

--- a/tests/test_install_ps1_python_fallback_venv.py
+++ b/tests/test_install_ps1_python_fallback_venv.py
@@ -78,6 +78,14 @@ def test_install_venv_reresolves_before_creating_venv(source: str):
     )
 
 
+def test_cn_fork_disallows_lower_python_fallbacks(source: str):
+    """Python <3.14 cannot satisfy this fork's requires-python contract."""
+    assert re.search(r"\$PythonFallbackVersions\s*=\s*@\(\)", source), (
+        "Hermes-CN-Core requires Python >=3.14, so the Windows installer must "
+        "not fall back to Python 3.12/3.13/3.10"
+    )
+
+
 def test_fallback_list_is_single_source_of_truth(source: str):
     """The fallback versions live in one shared constant, used by both paths.
 

--- a/tests/test_install_sh_repository_origin.py
+++ b/tests/test_install_sh_repository_origin.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="install.sh is POSIX-only")
+
+
+def _write_fake_git(fake_bin: Path, log_path: Path, *, fail_ssh_clone: bool = False) -> None:
+    fake_git = fake_bin / "git"
+    fail_flag = "1" if fail_ssh_clone else "0"
+    fake_git.write_text(
+        f"""#!/bin/sh
+printf '%s\\n' "$*" >> "{log_path}"
+if [ "$1" = "--version" ]; then
+  echo "git version 2.50.0"
+  exit 0
+fi
+if [ "$1" = "clone" ]; then
+  url=""
+  dest=""
+  for arg in "$@"; do
+    dest="$arg"
+    case "$arg" in
+      git@*|https://*) url="$arg" ;;
+    esac
+  done
+  if [ "{fail_flag}" = "1" ] && [ "${{url#git@}}" != "$url" ]; then
+    exit 1
+  fi
+  mkdir -p "$dest/.git"
+  exit 0
+fi
+exit 1
+""",
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+
+
+def _run_repository_stage(tmp_path: Path, *, fail_ssh_clone: bool = False):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    git_log = tmp_path / "git.log"
+    _write_fake_git(fake_bin, git_log, fail_ssh_clone=fail_ssh_clone)
+
+    install_dir = tmp_path / "install"
+    hermes_home = tmp_path / "home"
+    env = dict(os.environ)
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "HOME": str(tmp_path),
+            "HERMES_HOME": str(hermes_home),
+        }
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            str(INSTALL_SH),
+            "--stage",
+            "repository",
+            "--dir",
+            str(install_dir),
+            "--hermes-home",
+            str(hermes_home),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = git_log.read_text(encoding="utf-8").splitlines()
+    return result, calls
+
+
+def test_repository_stage_clones_hermes_cn_core_over_ssh(tmp_path: Path) -> None:
+    result, calls = _run_repository_stage(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    clone_calls = [call for call in calls if call.startswith("clone ")]
+    assert len(clone_calls) == 1
+    assert "git@github.com:Eynzof/Hermes-CN-Core.git" in clone_calls[0]
+
+
+def test_repository_stage_falls_back_to_hermes_cn_core_https(tmp_path: Path) -> None:
+    result, calls = _run_repository_stage(tmp_path, fail_ssh_clone=True)
+
+    assert result.returncode == 0, result.stderr
+    clone_calls = [call for call in calls if call.startswith("clone ")]
+    assert len(clone_calls) == 2
+    assert "git@github.com:Eynzof/Hermes-CN-Core.git" in clone_calls[0]
+    assert "https://github.com/Eynzof/Hermes-CN-Core.git" in clone_calls[1]


### PR DESCRIPTION
## Summary

Fixes #167 — two installer correctness bugs, no policy changes.

**1. Python runtime contract mismatch** (`pyproject.toml` requires `>=3.14`):
- `setup-hermes.sh`: `PYTHON_VERSION 3.11 → 3.14`; Termux minimum `(3, 11) → (3, 14)`; error message updated.
- `scripts/install.ps1`: `$PythonFallbackVersions = ["3.12","3.13","3.10"] → @()` so a missing Python 3.14 never falls back to an interpreter that cannot resolve project metadata.

**2. Fork-distributed installers clone the official repository** — SSH + HTTPS clone URLs and all Windows ZIP fallback URLs (`archive/<commit>.zip`, `refs/tags/…`, `refs/heads/…`) now point at **this repo**, plus stale usage examples that pointed at the official raw installers (`install.sh`, `install.ps1`).

Out of scope by design: any downstream Node-version or provider policy — this is correctness only.

## Testing

New behavior tests (RED→GREEN against the actual scripts, no network):

| Test | Verifies |
|---|---|
| `tests/hermes_cli/test_setup_hermes_script.py` (added cases) | setup runs fake `uv python find 3.14` / `uv venv --python 3.14`; Termux mode rejects a 3.13 interpreter with "must be 3.14+" |
| `tests/test_install_sh_repository_origin.py` (new) | `install.sh --stage repository` clones `git@github.com:Eynzof/Hermes-CN-Core.git` over SSH, and HTTPS URL on second attempt after forced SSH failure |
| `tests/test_install_ps1_python_fallback_venv.py` (new case) | lower-Python fallback list stays empty |

Regression run before submission: 25 installer-related test files — **73 passed / 0 failed / 2 skipped**; `bash -n setup-hermes.sh scripts/install.sh`; targeted `ruff check`; `git diff --check` clean.
