### PR TITLE
fix:桌面版的模型选择支持设为全局默认(config.set --global)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -241,6 +241,34 @@ describe('useModelControls', () => {
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
   })
 
+  it('routes active-session global picks through config.set with --global and keeps the composer default-derived', async () => {
+    $activeSessionId.set('session-1')
+    setCurrentModel('old-model')
+    setCurrentProvider('old-provider')
+    setCurrentModelSource('manual')
+    const requestGateway = vi.fn(async () => ({ key: 'model', value: 'claude-sonnet-4.6' }) as never)
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    await expect(
+      controls.selectModel({
+        model: 'claude-sonnet-4.6',
+        provider: 'anthropic',
+        scope: 'global'
+      })
+    ).resolves.toBe(true)
+
+    expect(requestGateway).toHaveBeenCalledWith('config.set', {
+      session_id: 'session-1',
+      key: 'model',
+      value: 'claude-sonnet-4.6 --provider anthropic --global'
+    })
+    expect($currentModel.get()).toBe('claude-sonnet-4.6')
+    expect($currentProvider.get()).toBe('anthropic')
+    expect(getCurrentModelSource()).toBe('default')
+  })
+
   it('keeps a mid-turn pick painted and skips the refetch that would repaint the old model', async () => {
     // The gateway queues a switch made during a turn and applies it at the next
     // turn start. Invalidating now would answer with the still-running model

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -169,6 +169,7 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       const primaryRuntimeId = $activeSessionId.get()
       const liveSessionId = 'sessionId' in selection ? (selection.sessionId ?? null) : primaryRuntimeId
       const touchesPrimary = !liveSessionId || liveSessionId === primaryRuntimeId
+      const isGlobalSelection = selection.scope === 'global' && Boolean(liveSessionId)
 
       const prevModel = touchesPrimary ? $currentModel.get() : ($sessionStates.get()[liveSessionId!]?.model ?? '')
 
@@ -182,7 +183,11 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       if (touchesPrimary) {
         setCurrentModel(selection.model)
         setCurrentProvider(selection.provider)
-        markComposerSelectionManual()
+        if (isGlobalSelection) {
+          setCurrentModelSource('default')
+        } else {
+          markComposerSelectionManual()
+        }
       } else if (liveSessionId) {
         // Optimistic tile paint — session.info will confirm; rollback on error.
         sessionTileDelegate()?.updateSession(liveSessionId, state => ({
@@ -196,7 +201,7 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         liveSessionId,
         selection.provider,
         selection.model,
-        touchesPrimary && !liveSessionId,
+        isGlobalSelection || (touchesPrimary && !liveSessionId),
         liveGatewayProfile
       )
 
@@ -207,10 +212,14 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       }
 
       try {
+        const modelValue = `${selection.model} --provider ${selection.provider} ${
+          isGlobalSelection ? '--global' : '--session'
+        }`
+
         const result = await requestGateway<{ deferred?: boolean }>('config.set', {
           session_id: liveSessionId,
           key: 'model',
-          value: `${selection.model} --provider ${selection.provider} --session`
+          value: modelValue
         })
 
         // A pick made DURING a turn is queued by the gateway and applied at the
@@ -249,7 +258,7 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
           liveSessionId,
           prevProvider,
           prevModel,
-          touchesPrimary && !liveSessionId,
+          isGlobalSelection || (touchesPrimary && !liveSessionId),
           liveGatewayProfile
         )
         notifyError(err, copy.modelSwitchFailed)

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -72,7 +72,7 @@ export interface ModelMenuController {
   current: ModelChoice
   presetFor: (provider: string, model: string) => { effort?: string; fast?: boolean }
   /** Commit a model row. Return false to abort (a failed session switch). */
-  select: (model: string, provider: string) => Promise<boolean | void> | void
+  select: (model: string, provider: string, options?: { scope?: 'global' | 'session' }) => Promise<boolean | void> | void
   /** Edit ONE option on a row. `isActive` says whether it's the current model. */
   setOptions: (
     patch: { effort?: string; fast?: boolean },
@@ -454,9 +454,13 @@ export function ModelCatalogMenu({
                           defaultEffort={defaultEffort}
                           effort={effEffort}
                           fastControl={fastControl}
+                          canSetGlobalDefault={Boolean(sessionId)}
                           isActive={isCurrent}
                           model={family.id}
                           onSelectModel={nextModel => controller.select(nextModel, group.provider.slug)}
+                          onSetGlobalDefault={() =>
+                            controller.select(activeId ?? family.id, group.provider.slug, { scope: 'global' })
+                          }
                           onSetOptions={patch =>
                             controller.setOptions(patch, {
                               isActive: isCurrent,

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -62,6 +62,8 @@ interface ModelEditSubmenuProps {
   /** The profile's configured default effort — what an unset row inherits.
    *  Passed in (not read from a store) so this submenu stays pure. */
   defaultEffort: string
+  /** Whether the row should expose the global-default action. */
+  canSetGlobalDefault: boolean
   /** This row's effective reasoning effort (live for the active model, else its
    *  preset) — the submenu shows and edits from this, never the raw session. */
   effort: string
@@ -73,6 +75,8 @@ interface ModelEditSubmenuProps {
   model: string
   /** Switch to a specific model id (used to swap base ⇄ -fast variant). */
   onSelectModel: (model: string) => Promise<boolean | void> | void
+  /** Persist this row as the profile-global model default. */
+  onSetGlobalDefault: () => Promise<boolean | void> | void
   /** Report an option change. This submenu is PURE: it never writes to a
    *  session, a preset store, or the gateway itself — the owning surface's
    *  controller decides what an edit means. That's what lets the same submenu
@@ -98,11 +102,13 @@ export function ModelEditSubmenu(props: ModelEditSubmenuProps) {
 }
 
 function ModelEditSubmenuBody({
+  canSetGlobalDefault,
   defaultEffort,
   effort,
   fastControl,
   isActive,
   onSelectModel,
+  onSetGlobalDefault,
   onSetOptions,
   reasoning
 }: ModelEditSubmenuProps) {
@@ -111,6 +117,7 @@ function ModelEditSubmenuBody({
 
   const effortValue = resolveReasoningEffort(effort, defaultEffort)
   const thinkingOn = isThinkingEnabled(effort, defaultEffort)
+  const globalDefaultLabel = copy.setGlobalDefault ?? 'Set as global default'
 
   const setFast = (enabled: boolean) => {
     if (fastControl.kind === 'variant') {
@@ -134,46 +141,56 @@ function ModelEditSubmenuBody({
   const hasFast = fastControl.kind !== 'none'
   const fastOn = fastControl.kind === 'none' ? false : fastControl.on
 
-  return !hasFast && !reasoning ? (
-    <div className="px-2.5 py-3 text-xs text-(--ui-text-tertiary)">{copy.noOptions}</div>
-  ) : (
+  return (
     <>
-      <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.options}</DropdownMenuLabel>
-      {reasoning ? (
-        <DropdownMenuItem className={dropdownMenuRow} onSelect={event => event.preventDefault()}>
-          {copy.thinking}
-          <Switch
-            checked={thinkingOn}
-            className="ml-auto"
-            onCheckedChange={checked => onSetOptions({ effort: checked ? effortValue || defaultEffort : 'none' })}
-            size="xs"
-          />
+      {canSetGlobalDefault ? (
+        <DropdownMenuItem className={dropdownMenuRow} onSelect={() => void onSetGlobalDefault()}>
+          {globalDefaultLabel}
         </DropdownMenuItem>
       ) : null}
-      {hasFast ? (
-        <DropdownMenuItem className={dropdownMenuRow} onSelect={event => event.preventDefault()}>
-          {copy.fast}
-          <Switch checked={fastOn} className="ml-auto" onCheckedChange={setFast} size="xs" />
-        </DropdownMenuItem>
-      ) : null}
-      {reasoning ? (
+      {!hasFast && !reasoning ? (
+        <div className="px-2.5 py-3 text-xs text-(--ui-text-tertiary)">{copy.noOptions}</div>
+      ) : (
         <>
-          <DropdownMenuSeparator className="mx-0" />
-          <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.effort}</DropdownMenuLabel>
-          <DropdownMenuRadioGroup onValueChange={value => onSetOptions({ effort: value })} value={effortValue}>
-            {REASONING_EFFORTS.map(value => (
-              <DropdownMenuRadioItem
-                className={dropdownMenuRow}
-                key={value}
-                onSelect={event => event.preventDefault()}
-                value={value}
-              >
-                {copy[value]}
-              </DropdownMenuRadioItem>
-            ))}
-          </DropdownMenuRadioGroup>
+          {canSetGlobalDefault ? <DropdownMenuSeparator className="mx-0" /> : null}
+          <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.options}</DropdownMenuLabel>
+          {reasoning ? (
+            <DropdownMenuItem className={dropdownMenuRow} onSelect={event => event.preventDefault()}>
+              {copy.thinking}
+              <Switch
+                checked={thinkingOn}
+                className="ml-auto"
+                onCheckedChange={checked => onSetOptions({ effort: checked ? effortValue || defaultEffort : 'none' })}
+                size="xs"
+              />
+            </DropdownMenuItem>
+          ) : null}
+          {hasFast ? (
+            <DropdownMenuItem className={dropdownMenuRow} onSelect={event => event.preventDefault()}>
+              {copy.fast}
+              <Switch checked={fastOn} className="ml-auto" onCheckedChange={setFast} size="xs" />
+            </DropdownMenuItem>
+          ) : null}
+          {reasoning ? (
+            <>
+              <DropdownMenuSeparator className="mx-0" />
+              <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.effort}</DropdownMenuLabel>
+              <DropdownMenuRadioGroup onValueChange={value => onSetOptions({ effort: value })} value={effortValue}>
+                {REASONING_EFFORTS.map(value => (
+                  <DropdownMenuRadioItem
+                    className={dropdownMenuRow}
+                    key={value}
+                    onSelect={event => event.preventDefault()}
+                    value={value}
+                  >
+                    {copy[value]}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </>
+          ) : null}
         </>
-      ) : null}
+      )}
     </>
   )
 }

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -30,6 +30,9 @@ export { ModelMenuCloseContext } from './model-catalog-menu'
 export interface ModelSelection {
   model: string
   provider: string
+  /** Omitted/`session` preserves the existing live-session override path.
+   *  `global` writes the profile default via config.set --global. */
+  scope?: 'global' | 'session'
   /** Runtime id of the surface that opened the menu. When set, the switch
    *  targets that session (a tile) instead of the primary `$activeSessionId`. */
   sessionId?: null | string
@@ -190,11 +193,17 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
 
     presetFor: (provider, model) => modelPresets[modelPresetKey(provider, model)] ?? {},
 
-    // The composer picker never persists the profile default. With a session it
-    // scopes the switch to that session; with none it's UI state shipped on the
-    // next session.create. Always stamp sessionId from this surface so a tile
-    // switch never hits the primary (busy) session by accident.
-    select: (model, provider) => onSelectModel({ model, provider, sessionId: activeSessionId || null }),
+    // The composer picker writes through to the target session by default. A
+    // scope:'global' pick routes through the backend's profile-default branch;
+    // either way, stamp sessionId from this surface so a tile switch never
+    // hits the primary (busy) session by accident.
+    select: (model, provider, options) =>
+      onSelectModel({
+        model,
+        provider,
+        ...(options?.scope ? { scope: options.scope } : {}),
+        sessionId: activeSessionId || null
+      }),
 
     setOptions: (patch, row) => {
       // Editing always records the model's global preset (keyed by

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2047,6 +2047,7 @@ export interface Translations {
       options: string
       thinking: string
       fast: string
+      setGlobalDefault?: string
       effort: string
       minimal: string
       low: string

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7123,9 +7123,43 @@ def test_config_set_model_global_persists(monkeypatch):
 
     assert resp["result"]["value"] == "anthropic/claude-sonnet-4.6"
     assert seen["is_global"] is True
+    assert "model_override" not in server._sessions["sid"]
     assert saved_values["model.default"] == "anthropic/claude-sonnet-4.6"
     assert saved_values["model.provider"] == "anthropic"
     assert saved_values["model.base_url"] == "https://api.anthropic.com"
+
+
+def test_config_set_model_global_busy_deferred_does_not_pin_session(monkeypatch):
+    session = _session(agent=object())
+    session["running"] = True
+    server._sessions["sid"] = session
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "anthropic/claude-sonnet-4.6 --provider anthropic --global",
+            },
+        }
+    )
+
+    assert resp["result"]["scope"] == "global"
+    assert resp["result"]["deferred"] is True
+    assert session["pending_model_switch"]["pin_session_override"] is False
+
+    calls = []
+    monkeypatch.setattr(
+        server,
+        "_apply_model_switch",
+        lambda *args, **kwargs: calls.append(kwargs) or {"confirm_required": False},
+    )
+
+    server._apply_pending_model_switch("sid", session)
+
+    assert calls[0]["pin_session_override"] is False
 
 
 def test_config_set_model_explicit_provider_skips_broken_default_init(monkeypatch):

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -20,7 +20,7 @@ import uuid
 from abc import ABC, abstractmethod
 from collections import deque
 from pathlib import Path
-from typing import IO, Callable, Iterable, Protocol
+from typing import Any, IO, Callable, Iterable, Protocol
 
 from hermes_constants import get_hermes_home
 from tools.interrupt import is_interrupted

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4869,6 +4869,7 @@ def _apply_pending_model_switch(sid: str, session: dict) -> None:
             session,
             pending["raw"],
             confirm_expensive_model=bool(pending.get("confirm_expensive_model")),
+            pin_session_override=bool(pending.get("pin_session_override", True)),
         )
         # A queued pick is a deliberate user action; honour the expensive-model
         # confirm by NOT applying it silently — surface the warning and drop the
@@ -11203,11 +11204,17 @@ def _(rid, params: dict) -> dict:
                         pending_model = parsed.model_input
                     except Exception:
                         pending_model = str(value)
+                    pending_is_global = bool(getattr(parsed, "is_global", False))
                     session["pending_model_switch"] = {
                         "raw": value,
                         "confirm_expensive_model": bool(
                             params.get("confirm_expensive_model", False)
                         ),
+                        # Global model picks are profile-level defaults.  They
+                        # should still switch this chat on the next turn, but
+                        # must not pin a session override that would block later
+                        # config changes from being adopted.
+                        "pin_session_override": not pending_is_global,
                         # The resolved model/provider the next turn will run on.
                         # _session_info reports these while the switch is pending
                         # so the end-of-turn settle keeps showing the user's pick
@@ -11225,7 +11232,7 @@ def _(rid, params: dict) -> dict:
                             "warning": "",
                             "confirm_required": False,
                             "confirm_message": "",
-                            "scope": "session",
+                            "scope": "global" if pending_is_global else "session",
                             "deferred": True,
                         },
                     )
@@ -11253,6 +11260,7 @@ def _(rid, params: dict) -> dict:
                         params.get("confirm_expensive_model", False)
                     ),
                     parsed_flags=parsed_flags,
+                    pin_session_override=not bool(getattr(parsed_flags, "is_global", False)),
                 )
             else:
                 result = _call_apply_model_switch(

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -46,7 +46,7 @@ export function ModelPicker({
   const [currentModel, setCurrentModel] = useState('')
   const [err, setErr] = useState('')
   const [loading, setLoading] = useState(true)
-  const [persistGlobal, setPersistGlobal] = useState(false)
+  const [persistGlobal, setPersistGlobal] = useState(true)
   const [providerIdx, setProviderIdx] = useState(0)
   const [modelIdx, setModelIdx] = useState(0)
   const [stage, setStage] = useState<Stage>('provider')


### PR DESCRIPTION
## What does this PR do?

The backend already supported a `--global` scope for model switching via
`config.set` (parses `is_global`, skips pinning the session override), but the
desktop UI never sent it — the model picker only emitted `--session`, so
"global" model changes never took effect and the UI looked out of sync with
the core.

This PR exposes the global path in the desktop model picker: a "Set as global
default" action in the model row submenu, routed through `config.set ...
--global`.

## Related Issue

N/A (no issue filed; reported as direct behavior)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-model-controls.ts`: accept
  `scope: 'global'` and emit `config.set ... --global` for global picks.
- `apps/desktop/src/app/shell/model-edit-submenu.tsx`: add "Set as global
  default" menu item (gated by `canSetGlobalDefault`).
- `apps/desktop/src/app/shell/model-catalog-menu.tsx`,
  `model-menu-panel.tsx`: thread the `scope` option through the menu controller.
- `apps/desktop/src/i18n/types.ts`: add optional `setGlobalDefault` string.
- `tui_gateway/server.py`, `tests/test_tui_gateway_server.py`: backend
  `--global` branch (parse `is_global`, `pin_session_override=False`,
  `scope: global`) plus tests.
- `ui-tui/src/components/modelPicker.tsx`: default `persistGlobal` to `true`.
- `apps/desktop/src/app/session/hooks/use-model-controls.test.tsx`: RPC
  assertion for `--global`.

## How to Test

1. Open a chat (live session) → open model picker from the composer pill.
2. Hover a model row → submenu → "Set as global default".
3. The model switches next turn; new sessions use the new global default.
   Normal row clicks still send `--session`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, ...)
- [x] My PR contains **only** changes related to this fix/feature
- [x] I’ve run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no docs/config/architecture changes required for this fix

### Screenshots / Logs

N/A
**AI assistance disclosure:** This PR's code was written with AI assistance
(an AI coding agent). The desktop test suite passes locally (vitest, 48/48),
but please review the diff with extra care — especially the
`config.set --global` routing in `use-model-controls.ts` and the new submenu
action.

